### PR TITLE
Adding a protobuff file for pose estimation

### DIFF
--- a/tensorflow_lite_support/cc/task/vision/proto/BUILD
+++ b/tensorflow_lite_support/cc/task/vision/proto/BUILD
@@ -236,3 +236,23 @@ cc_library(
     hdrs = ["embeddings_proto_inc.h"],
     deps = [":embeddings_cc_proto"],
 )
+
+# PoseEstimation protos
+
+proto_library(
+    name = "poses_proto"
+    srcs = ["poses.proto"]
+)
+
+cc_proto_library(
+    name = "poses_cc_proto",
+    deps = [
+        ":poses_proto",
+    ],
+)
+
+cc_library(
+    name = "poses_proto_inc"
+    hdrs = ["poses_proto_inc.h"]
+    deps = [":poses_cc_proto"]
+)

--- a/tensorflow_lite_support/cc/task/vision/proto/poses.proto
+++ b/tensorflow_lite_support/cc/task/vision/proto/poses.proto
@@ -1,0 +1,58 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+syntax = "proto2";
+
+package tflite.task.vision;
+
+// Results of performing pose estimation.
+// The "person" object which stores the keypoints and the average score.
+message PoseResult {
+  repeated KeyPoint keypoint = 1;
+  optional float score = 2 [default = 0.0];
+}
+
+message KeyPoint {
+  optional BodyPart bodypart = 1 [default = NOSE];
+  optional Position position = 2;
+
+
+  message Position {
+    // The X coordinate of a point.
+    optional int32 pos_x = 1 [default = 0];
+    // The Y coordinate of a point.
+    optional int32 pos_y = 2 [default = 0];
+  }
+
+  // The individual points to be taken into consideration.
+  enum BodyPart {
+    NOSE = 0;
+    LEFT_EYE = 1;
+    RIGHT_EYE = 2;
+    LEFT_EAR = 3;
+    RIGHT_EAR = 4;
+    LEFT_SHOULDER = 5;
+    RIGHT_SHOULDER = 6;
+    LEFT_ELBOW = 7;
+    LEFT_WRIST = 8;
+    RIGHT_WRIST = 9;
+    LEFT_HIP = 10;
+    RIGHT_HIP = 11;
+    LEFT_KNEE = 12;
+    RIGHT_KNEE = 13;
+    LEFT_ANKLE = 14;
+    RIGHT_ANKLE = 15;
+  }
+}

--- a/tensorflow_lite_support/cc/task/vision/proto/poses.proto
+++ b/tensorflow_lite_support/cc/task/vision/proto/poses.proto
@@ -17,13 +17,6 @@ syntax = "proto2";
 
 package tflite.task.vision;
 
-// Results of performing pose estimation.
-// The "person" object which stores the keypoints and the average score.
-message PoseResult {
-  repeated KeyPoint keypoint = 1;
-  optional float score = 2 [default = 0.0];
-}
-
 message KeyPoint {
   optional BodyPart bodypart = 1 [default = NOSE];
   optional Position position = 2;
@@ -55,4 +48,19 @@ message KeyPoint {
     LEFT_ANKLE = 14;
     RIGHT_ANKLE = 15;
   }
+}
+
+// The "person" object which stores the keypoints and the average score.
+// Result produced from one "person" object.
+message Person {
+  repeated KeyPoint keypoint = 1;
+  optional float score = 2 [default = 0.0];
+}
+
+message PoseEstimationResult {
+  // The pose estimation result produced by each of the model output.
+  //
+  // Except in advanced cases, the pose estimation model has a single output,
+  // and this list is thus made of a single element.
+  repeated Person = 3;
 }

--- a/tensorflow_lite_support/cc/task/vision/proto/poses_proto_inc.h
+++ b/tensorflow_lite_support/cc/task/vision/proto/poses_proto_inc.h
@@ -1,0 +1,19 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_SUPPORT_CC_TASK_VISION_PROTO_POSES_PROTO_INC_H_
+#define TENSORFLOW_LITE_SUPPORT_CC_TASK_VISION_PROTO_POSES_PROTO_INC_H_
+
+#include "tensorflow_lite_support/cc/task/vision/proto/poses.pb.h"
+#endif  // TENSORFLOW_LITE_SUPPORT_CC_TASK_VISION_PROTO_POSES_PROTO_INC_H_


### PR DESCRIPTION
This should lay the founding stones for a pose estimation library. Once we're done with this, we can work on properly setting up ```PoseResult``` which will be used by ```Postprocess``` interface to collect the result from the engine.  Used [this](https://medium.com/tensorflow/track-human-poses-in-real-time-on-android-with-tensorflow-lite-e66d0f3e6f9e)  article for inspiration