### PR TITLE
Audio classifier pybinds and dataclasses

### DIFF
--- a/tensorflow_lite_support/cc/task/processor/proto/BUILD
+++ b/tensorflow_lite_support/cc/task/processor/proto/BUILD
@@ -20,6 +20,13 @@ cc_proto_library(
     ],
 )
 
+support_py_proto_library(
+    name = "classifications_py_pb2",
+    srcs = ["classifications.proto"],
+    api_version = 2,
+    proto_deps = [":classifications_proto"],
+)
+
 proto_library(
     name = "class_proto",
     srcs = ["class.proto"],
@@ -30,6 +37,13 @@ cc_proto_library(
     deps = [
         ":class_proto",
     ],
+)
+
+support_py_proto_library(
+    name = "class_py_pb2",
+    srcs = ["class.proto"],
+    api_version = 2,
+    proto_deps = [":class_proto"],
 )
 
 proto_library(

--- a/tensorflow_lite_support/python/task/audio/BUILD
+++ b/tensorflow_lite_support/python/task/audio/BUILD
@@ -1,0 +1,21 @@
+# Placeholder for internal Python strict library compatibility macro.
+
+package(
+    default_visibility = ["//tensorflow_lite_support:internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+py_library(
+    name = "audio_classifier",
+    srcs = [
+        "audio_classifier.py",
+    ],
+    deps = [
+        "//tensorflow_lite_support/python/task/core/proto:base_options_py_pb2",
+        "//tensorflow_lite_support/python/task/processor/proto:classification_options_pb2",
+        "//tensorflow_lite_support/python/task/processor/proto:classifications_pb2",
+        "//tensorflow_lite_support/python/task/audio/core:tensor_audio",
+        "//tensorflow_lite_support/python/task/audio/core/pybinds:_pywrap_audio_buffer",
+        "//tensorflow_lite_support/python/task/audio/pybinds:_pywrap_audio_classifier",
+    ],
+)

--- a/tensorflow_lite_support/python/task/audio/audio_classifier.py
+++ b/tensorflow_lite_support/python/task/audio/audio_classifier.py
@@ -1,0 +1,134 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Audio classifier task."""
+
+import dataclasses
+
+from tensorflow_lite_support.python.task.core.proto import base_options_pb2
+from tensorflow_lite_support.python.task.processor.proto import classification_options_pb2
+from tensorflow_lite_support.python.task.processor.proto import classifications_pb2
+from tensorflow_lite_support.python.task.audio.core import tensor_audio
+from tensorflow_lite_support.python.task.audio.core import audio_record
+from tensorflow_lite_support.python.task.audio.core.pybinds import _pywrap_audio_buffer
+from tensorflow_lite_support.python.task.audio.pybinds import _pywrap_audio_classifier
+
+_CppAudioFormat = _pywrap_audio_buffer.AudioFormat
+_CppAudioBuffer = _pywrap_audio_buffer.AudioBuffer
+_CppAudioClassifier = _pywrap_audio_classifier.AudioClassifier
+_ClassificationOptions = classification_options_pb2.ClassificationOptions
+_BaseOptions = base_options_pb2.BaseOptions
+
+
+@dataclasses.dataclass
+class AudioClassifierOptions:
+  """Options for the audio classifier task."""
+  base_options: _BaseOptions
+  classification_options: _ClassificationOptions = _ClassificationOptions()
+
+
+class AudioClassifier(object):
+  """Class that performs classification on audio."""
+
+  def __init__(self, options: AudioClassifierOptions,
+               classifier: _CppAudioClassifier) -> None:
+    """Initializes the `AudioClassifier` object."""
+    # Creates the object of C++ AudioClassifier class.
+    self._options = options
+    self._classifier = classifier
+
+  @classmethod
+  def create_from_file(cls, file_path: str) -> "AudioClassifier":
+    """Creates the `AudioClassifier` object from a TensorFlow Lite model.
+    Args:
+      file_path: Path to the model.
+    Returns:
+      `AudioClassifier` object that's created from `options`.
+    Raises:
+      status.StatusNotOk if failed to create `AudioClassifier` object from the
+      provided file such as invalid file.
+    """
+    # TODO(b/220931229): Raise RuntimeError instead of status.StatusNotOk.
+    # Need to import the module to catch this error:
+    # `from pybind11_abseil import status`
+    # see https://github.com/pybind/pybind11_abseil#abslstatusor.
+    base_options = _BaseOptions(file_name=file_path)
+    options = AudioClassifierOptions(base_options=base_options)
+    return cls.create_from_options(options)
+
+  @classmethod
+  def create_from_options(cls,
+                          options: AudioClassifierOptions) -> "AudioClassifier":
+    """Creates the `AudioClassifier` object from audio classifier options.
+    Args:
+      options: Options for the audio classifier task.
+    Returns:
+      `AudioClassifier` object that's created from `options`.
+    Raises:
+      status.StatusNotOk if failed to create `AudioClassifier` object from
+      `AudioClassifierOptions` such as missing the model.
+    """
+    # TODO(b/220931229): Raise RuntimeError instead of status.StatusNotOk.
+    # Need to import the module to catch this error:
+    # `from pybind11_abseil import status`
+    # see https://github.com/pybind/pybind11_abseil#abslstatusor.
+    classifier = _CppAudioClassifier.create_from_options(
+      options.base_options, options.classification_options)
+    return cls(options, classifier)
+
+  def create_input_tensor_audio(self) -> tensor_audio.TensorAudio:
+    """Creates a TensorAudio instance to store the audio input.
+    Returns:
+        A TensorAudio instance.
+    """
+    return tensor_audio.TensorAudio(audio_format=self.required_audio_format,
+                                    buffer_size=self.required_input_buffer_size)
+
+  def create_audio_record(self) -> audio_record.AudioRecord:
+    """Creates an AudioRecord instance to record audio.
+    Returns:
+        An AudioRecord instance.
+    """
+    return audio_record.AudioRecord(self.required_audio_format.channels,
+                                    self.required_audio_format.sample_rate,
+                                    self.required_input_buffer_size)
+
+  def classify(
+      self,
+      audio: tensor_audio.TensorAudio,
+  ) -> classifications_pb2.ClassificationResult:
+    """Performs classification on the provided TensorAudio.
+
+    Args:
+      audio: Tensor audio, used to extract the feature vectors.
+    Returns:
+      classification result.
+    Raises:
+      status.StatusNotOk if failed to get the feature vector. Need to import the
+        module to catch this error: `from pybind11_abseil
+        import status`, see
+        https://github.com/pybind/pybind11_abseil#abslstatusor.
+    """
+    return self._classifier.classify(_CppAudioBuffer(audio.buffer,
+                                                     audio.buffer_size,
+                                                     audio.format))
+
+  @property
+  def required_input_buffer_size(self) -> int:
+    """Gets the required input buffer size for the model."""
+    return self._classifier.get_required_input_buffer_size()
+
+  @property
+  def required_audio_format(self) -> _CppAudioFormat:
+    """Gets the required audio format for the model."""
+    return self._classifier.get_required_audio_format()

--- a/tensorflow_lite_support/python/task/audio/pybinds/BUILD
+++ b/tensorflow_lite_support/python/task/audio/pybinds/BUILD
@@ -1,0 +1,27 @@
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "pybind_extension")
+# Placeholder for internal Python strict library compatibility macro.
+
+package(
+    default_visibility = [
+        "//tensorflow_lite_support:internal",
+    ],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+pybind_extension(
+    name = "_pywrap_audio_classifier",
+    srcs = [
+        "_pywrap_audio_classifier.cc",
+    ],
+    module_name = "_pywrap_audio_classifier",
+    deps = [
+        "//tensorflow_lite_support/cc/port:statusor",
+        "//tensorflow_lite_support/cc/task/processor/proto:classification_options_cc_proto",
+        "//tensorflow_lite_support/cc/task/audio:audio_classifier",
+        "//tensorflow_lite_support/cc/task/audio/core:audio_buffer",
+        "//tensorflow_lite_support/python/task/core/pybinds:task_utils",
+        "@pybind11",
+        "@pybind11_abseil//pybind11_abseil:status_casters",
+        "@pybind11_protobuf//pybind11_protobuf:native_proto_caster",
+    ],
+)

--- a/tensorflow_lite_support/python/task/audio/pybinds/_pywrap_audio_classifier.cc
+++ b/tensorflow_lite_support/python/task/audio/pybinds/_pywrap_audio_classifier.cc
@@ -1,0 +1,82 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "pybind11/pybind11.h"
+#include "pybind11_abseil/status_casters.h"  // from @pybind11_abseil
+#include "pybind11_protobuf/native_proto_caster.h"  // from @pybind11_protobuf
+#include "tensorflow_lite_support/cc/port/statusor.h"
+#include "tensorflow_lite_support/cc/task/processor/proto/classification_options.pb.h"
+#include "tensorflow_lite_support/cc/task/audio/audio_classifier.h"
+#include "tensorflow_lite_support/cc/task/audio/core/audio_buffer.h"
+#include "tensorflow_lite_support/python/task/core/pybinds/task_utils.h"
+
+namespace tflite {
+namespace task {
+namespace audio {
+
+namespace {
+namespace py = ::pybind11;
+using PythonBaseOptions = ::tflite::python::task::core::BaseOptions;
+using CppBaseOptions = ::tflite::task::core::BaseOptions;
+}  // namespace
+
+PYBIND11_MODULE(_pywrap_audio_classifier, m) {
+  // python wrapper for C++ AudioClassifier class which shouldn't be directly used
+  // by the users.
+  pybind11::google::ImportStatusModule();
+  pybind11_protobuf::ImportNativeProtoCasters();
+
+  py::class_<AudioClassifier>(m, "AudioClassifier")
+      .def_static(
+          "create_from_options",
+          [](const PythonBaseOptions& base_options,
+             const processor::ClassificationOptions& classification_options) {
+            AudioClassifierOptions options;
+            auto cpp_base_options =
+                core::convert_to_cpp_base_options(base_options);
+            options.set_allocated_base_options(cpp_base_options.release());
+
+            if (classification_options.has_display_names_locale()) {
+              options.set_display_names_locale(
+                  classification_options.display_names_locale());
+            }
+            if (classification_options.has_max_results()) {
+              options.set_max_results(classification_options.max_results());
+            }
+            if (classification_options.has_score_threshold()) {
+              options.set_score_threshold(
+                  classification_options.score_threshold());
+            }
+            options.mutable_class_name_allowlist()->CopyFrom(
+                classification_options.class_name_allowlist());
+            options.mutable_class_name_denylist()->CopyFrom(
+                classification_options.class_name_denylist());
+
+            return AudioClassifier::CreateFromOptions(options);
+          })
+      .def("classify",
+           [](AudioClassifier& self, const AudioBuffer& audio)
+                   -> tflite::support::StatusOr<ClassificationResult> {
+               return self.Classify(audio);
+           })
+      .def("get_required_audio_format",
+           &AudioClassifier::GetRequiredAudioFormat)
+      .def("get_required_input_buffer_size",
+           &AudioClassifier::GetRequiredInputBufferSize);
+}
+
+}  // namespace vision
+}  // namespace task
+}  // namespace tflite

--- a/tensorflow_lite_support/python/task/processor/proto/BUILD
+++ b/tensorflow_lite_support/python/task/processor/proto/BUILD
@@ -27,7 +27,7 @@ py_library(
     name = "class_pb2",
     srcs = ["class_pb2.py"],
     deps = [
-        "//tensorflow_lite_support/cc/task/vision/proto:class_py_pb2",
+        "//tensorflow_lite_support/cc/task/processor/proto:class_py_pb2",
     ],
 )
 
@@ -35,7 +35,7 @@ py_library(
     name = "classifications_pb2",
     srcs = ["classifications_pb2.py"],
     deps = [
-        "//tensorflow_lite_support/cc/task/vision/proto:classifications_py_pb2",
+        "//tensorflow_lite_support/cc/task/processor/proto:classifications_py_pb2",
     ],
 )
 

--- a/tensorflow_lite_support/python/task/processor/proto/class_pb2.py
+++ b/tensorflow_lite_support/python/task/processor/proto/class_pb2.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 """Class protobuf."""
 
-from tensorflow_lite_support.cc.task.vision.proto import class_pb2
+from tensorflow_lite_support.cc.task.processor.proto import class_pb2
 
 Category = class_pb2.Class

--- a/tensorflow_lite_support/python/task/processor/proto/classifications_pb2.py
+++ b/tensorflow_lite_support/python/task/processor/proto/classifications_pb2.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Classifications protobuf."""
 
-from tensorflow_lite_support.cc.task.vision.proto import classifications_pb2
+from tensorflow_lite_support.cc.task.processor.proto import classifications_pb2
 
 Classifications = classifications_pb2.Classifications
 ClassificationResult = classifications_pb2.ClassificationResult

--- a/tensorflow_lite_support/python/test/task/audio/BUILD
+++ b/tensorflow_lite_support/python/test/task/audio/BUILD
@@ -1,0 +1,26 @@
+# Placeholder for internal Python strict test compatibility macro.
+
+package(
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+py_test(
+    name = "audio_classifier_test",
+    srcs = ["audio_classifier_test.py"],
+    data = [
+        "//tensorflow_lite_support/cc/test/testdata/task/audio:test_audio_clips",
+        "//tensorflow_lite_support/cc/test/testdata/task/audio:test_models",
+    ],
+    deps = [
+        "//tensorflow_lite_support/python/task/core/proto:base_options_py_pb2",
+        "//tensorflow_lite_support/python/task/processor/proto:class_pb2",
+        "//tensorflow_lite_support/python/task/processor/proto:classification_options_pb2",
+        "//tensorflow_lite_support/python/task/processor/proto:classifications_pb2",
+        "//tensorflow_lite_support/python/task/audio:audio_classifier",
+        "//tensorflow_lite_support/python/test:base_test",
+        "//tensorflow_lite_support/python/test:test_util",
+        "@absl_py//absl/testing:parameterized",
+        "@com_google_protobuf//:protobuf_python",
+    ],
+)

--- a/tensorflow_lite_support/python/test/task/audio/audio_classifier_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/audio_classifier_test.py
@@ -1,0 +1,146 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for audio_classifier."""
+
+import enum
+import json
+
+from absl.testing import parameterized
+from google.protobuf import json_format
+# TODO(b/220067158): Change to import tensorflow and leverage tf.test once
+# fixed the dependency issue.
+import unittest
+
+from tensorflow_lite_support.python.task.core.proto import base_options_pb2
+from tensorflow_lite_support.python.task.processor.proto import class_pb2
+from tensorflow_lite_support.python.task.processor.proto import classification_options_pb2
+from tensorflow_lite_support.python.task.processor.proto import classifications_pb2
+from tensorflow_lite_support.python.task.audio import audio_classifier
+from tensorflow_lite_support.python.task.audio.core import tensor_audio
+from tensorflow_lite_support.python.test import base_test
+from tensorflow_lite_support.python.test import test_util
+
+
+_BaseOptions = base_options_pb2.BaseOptions
+_AudioClassifier = audio_classifier.AudioClassifier
+_AudioClassifierOptions = audio_classifier.AudioClassifierOptions
+
+_FIXED_INPUT_SIZE_MODEL_FILE = 'yamnet_audio_classifier_with_metadata.tflite'
+_SPEECH_AUDIO_FILE = 'speech.wav'
+_FIXED_INPUT_SIZE_MODEL_CLASSIFICATIONS = {
+  'scores': [
+    {
+      'index': 0,
+      'score': 0.91796875,
+      'class_name': 'Speech'
+    },
+    {
+      'index': 500,
+      'score': 0.05859375,
+      'class_name': 'Inside, small room'
+    },
+    {
+      'index': 494,
+      'score': 0.015625,
+      'class_name': 'Silence'
+    }
+  ]
+}
+_ALLOW_LIST = ['Speech', 'Inside, small room']
+_DENY_LIST = ['Speech']
+_SCORE_THRESHOLD = 0.5
+_MAX_RESULTS = 3
+_ACCEPTABLE_ERROR_RANGE = 0.000001
+
+
+class ModelFileType(enum.Enum):
+  FILE_CONTENT = 1
+  FILE_NAME = 2
+
+
+class AudioClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
+
+  def setUp(self):
+    super().setUp()
+
+  @staticmethod
+  def create_classifier_from_options(base_options, **classification_options):
+    classification_options = classification_options_pb2.ClassificationOptions(
+        **classification_options)
+    options = _AudioClassifierOptions(
+        base_options=base_options,
+        classification_options=classification_options)
+    classifier = _AudioClassifier.create_from_options(options)
+    return classifier
+
+  @staticmethod
+  def build_test_data(classifications):
+    expected_result = classifications_pb2.ClassificationResult()
+
+    for index, (head_name, categories) in enumerate(classifications.items()):
+      classifications = classifications_pb2.Classifications(
+        head_index=index, head_name=head_name)
+      classifications.classes.extend(
+          [class_pb2.Category(**args) for args in categories])
+      expected_result.classifications.append(classifications)
+
+    expected_result_dict = json.loads(
+        json_format.MessageToJson(expected_result))
+
+    return expected_result_dict
+
+  @parameterized.parameters(
+    (_FIXED_INPUT_SIZE_MODEL_FILE, ModelFileType.FILE_NAME,
+     _SPEECH_AUDIO_FILE, 3, _FIXED_INPUT_SIZE_MODEL_CLASSIFICATIONS),
+    (_FIXED_INPUT_SIZE_MODEL_FILE, ModelFileType.FILE_CONTENT,
+     _SPEECH_AUDIO_FILE, 3, _FIXED_INPUT_SIZE_MODEL_CLASSIFICATIONS),
+  )
+  def test_classify_model(
+      self, model_name, model_file_type, audio_file_name, max_results,
+      expected_classifications
+  ):
+    # Creates classifier.
+    model_path = test_util.get_test_data_path(model_name)
+    if model_file_type is ModelFileType.FILE_NAME:
+      base_options = _BaseOptions(file_name=model_path)
+    elif model_file_type is ModelFileType.FILE_CONTENT:
+      with open(model_path, "rb") as f:
+        model_content = f.read()
+      base_options = _BaseOptions(file_content=model_content)
+    else:
+      # Should never happen
+      raise ValueError("model_file_type is invalid.")
+
+    classifier = self.create_classifier_from_options(base_options,
+                                                     max_results=max_results)
+
+    # Load the input audio file.
+    test_audio_path = test_util.get_test_data_path(audio_file_name)
+    tensor = tensor_audio.TensorAudio.create_from_wav_file(
+      test_audio_path, classifier.required_input_buffer_size)
+
+    # Classifies the input.
+    audio_result = classifier.classify(tensor)
+    audio_result_dict = json.loads(json_format.MessageToJson(audio_result))
+
+    # Builds test data.
+    expected_result_dict = self.build_test_data(expected_classifications)
+
+    # Comparing results.
+    self.assertDeepAlmostEqual(
+      audio_result_dict, expected_result_dict, delta=_ACCEPTABLE_ERROR_RANGE)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
- Added audio classifier implementation (pybinds + dataclasses)
- A test for the fixed input size model
- Moved class_pb2 and classifications_pb2 python protos to use protos located in `cc/task/processor/proto` since the audio classification result expects a `headName` field. Note: This doesn't break the image classifier tests.