### PR TITLE
Migrating Python Task API tests to use tf.test along with some minor fixes

### DIFF
--- a/tensorflow_lite_support/python/task/audio/audio_classifier.py
+++ b/tensorflow_lite_support/python/task/audio/audio_classifier.py
@@ -132,5 +132,9 @@ class AudioClassifier(object):
 
   @property
   def required_audio_format(self) -> _CppAudioFormat:
-    """Gets the required audio format for the model."""
+    """Gets the required audio format for the model.
+
+    Raises:
+      RuntimeError: If failed to get the required audio format.
+    """
     return self._classifier.get_required_audio_format()

--- a/tensorflow_lite_support/python/task/audio/audio_embedder.py
+++ b/tensorflow_lite_support/python/task/audio/audio_embedder.py
@@ -151,5 +151,9 @@ class AudioEmbedder(object):
 
   @property
   def required_audio_format(self) -> _CppAudioFormat:
-    """Gets the required audio format for the model."""
+    """Gets the required audio format for the model.
+
+    Raises:
+      RuntimeError: If failed to get the required audio format.
+    """
     return self._embedder.get_required_audio_format()

--- a/tensorflow_lite_support/python/task/vision/core/BUILD
+++ b/tensorflow_lite_support/python/task/vision/core/BUILD
@@ -20,20 +20,3 @@ py_library(
         "//tensorflow_lite_support/python/task/vision/core/pybinds:image_utils",
     ],
 )
-
-py_test(
-    name = "tensor_image_test",
-    srcs = ["tensor_image_test.py"],
-    data = [
-        "//tensorflow_lite_support/cc/test/testdata/task/vision:test_images",
-    ],
-    deps = [
-        ":color_space_type",
-        ":tensor_image",
-        # build rule placeholder: numpy dep,
-        # build rule placeholder: tensorflow dep,
-        "//tensorflow_lite_support/python/task/vision/core/pybinds:image_utils",
-        "//tensorflow_lite_support/python/test:test_util",
-        "@absl_py//absl/testing:parameterized",
-    ],
-)

--- a/tensorflow_lite_support/python/task/vision/pybinds/_pywrap_image_classifier.cc
+++ b/tensorflow_lite_support/python/task/vision/pybinds/_pywrap_image_classifier.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow_lite_support/python/task/vision/pybinds/_pywrap_object_detector.cc
+++ b/tensorflow_lite_support/python/task/vision/pybinds/_pywrap_object_detector.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow_lite_support/python/test/BUILD
+++ b/tensorflow_lite_support/python/test/BUILD
@@ -10,6 +10,9 @@ py_library(
     testonly = 1,
     srcs = ["base_test.py"],
     srcs_version = "PY3",
+    deps = [
+        # build rule placeholder: tensorflow dep,
+    ],
 )
 
 py_library(

--- a/tensorflow_lite_support/python/test/base_test.py
+++ b/tensorflow_lite_support/python/test/base_test.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Base TestCase for the unit tests."""
 
-import unittest
+import tensorflow as tf
 
 __unittest = True  # Allows shorter stack trace for .assertDeepAlmostEqual  pylint: disable=invalid-name
 
 
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(tf.test.TestCase):
   """Base test case."""
 
   def assertDeepAlmostEqual(self, expected, actual, **kwargs):

--- a/tensorflow_lite_support/python/test/task/audio/BUILD
+++ b/tensorflow_lite_support/python/test/task/audio/BUILD
@@ -13,6 +13,7 @@ py_test(
         "//tensorflow_lite_support/cc/test/testdata/task/audio:test_models",
     ],
     deps = [
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/audio:audio_embedder",
         "//tensorflow_lite_support/python/task/audio/core:audio_record",
         "//tensorflow_lite_support/python/task/audio/core:tensor_audio",
@@ -32,6 +33,7 @@ py_test(
         "//tensorflow_lite_support/cc/test/testdata/task/audio:test_models",
     ],
     deps = [
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/audio:audio_classifier",
         "//tensorflow_lite_support/python/task/audio/core:audio_record",
         "//tensorflow_lite_support/python/task/audio/core:tensor_audio",

--- a/tensorflow_lite_support/python/test/task/audio/audio_classifier_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/audio_classifier_test.py
@@ -15,11 +15,11 @@
 
 import enum
 import json
+import tensorflow as tf
 
 from absl.testing import parameterized
-
 from google.protobuf import json_format
-import unittest
+from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio import audio_classifier
 from tensorflow_lite_support.python.task.audio.core import audio_record
 from tensorflow_lite_support.python.task.audio.core import tensor_audio
@@ -30,10 +30,7 @@ from tensorflow_lite_support.python.task.processor.proto import classifications_
 from tensorflow_lite_support.python.test import base_test
 from tensorflow_lite_support.python.test import test_util
 
-# TODO(b/220067158): Change to import tensorflow and leverage tf.test once
-# fixed the dependency issue.
-
-_mock = unittest.mock
+_mock = test.mock
 _BaseOptions = base_options_pb2.BaseOptions
 _AudioClassifier = audio_classifier.AudioClassifier
 _AudioClassifierOptions = audio_classifier.AudioClassifierOptions
@@ -332,4 +329,4 @@ class AudioClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  tf.test.main()

--- a/tensorflow_lite_support/python/test/task/audio/audio_embedder_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/audio_embedder_test.py
@@ -14,12 +14,10 @@
 """Tests for audio_embedder."""
 
 import enum
+import tensorflow as tf
 
 from absl.testing import parameterized
-# TODO(b/220067158): Change to import tensorflow and leverage tf.test once
-# fixed the dependency issue.
-import unittest
-
+from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio import audio_embedder
 from tensorflow_lite_support.python.task.audio.core import audio_record
 from tensorflow_lite_support.python.task.audio.core import tensor_audio
@@ -28,7 +26,7 @@ from tensorflow_lite_support.python.task.processor.proto import embedding_option
 from tensorflow_lite_support.python.test import base_test
 from tensorflow_lite_support.python.test import test_util
 
-_mock = unittest.mock
+_mock = test.mock
 _BaseOptions = base_options_pb2.BaseOptions
 _AudioEmbedder = audio_embedder.AudioEmbedder
 _AudioEmbedderOptions = audio_embedder.AudioEmbedderOptions
@@ -176,4 +174,4 @@ class AudioEmbedderTest(parameterized.TestCase, base_test.BaseTestCase):
 
 
 if __name__ == "__main__":
-  unittest.main()
+  tf.test.main()

--- a/tensorflow_lite_support/python/test/task/audio/core/BUILD
+++ b/tensorflow_lite_support/python/test/task/audio/core/BUILD
@@ -10,6 +10,7 @@ py_test(
     srcs = ["audio_record_test.py"],
     deps = [
         # build rule placeholder: numpy dep,
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/audio/core:audio_record",
     ],
 )
@@ -22,6 +23,7 @@ py_test(
     ],
     deps = [
         # build rule placeholder: numpy dep,
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/audio/core:audio_record",
         "//tensorflow_lite_support/python/task/audio/core:tensor_audio",
         "//tensorflow_lite_support/python/task/audio/core/pybinds:_pywrap_audio_buffer",

--- a/tensorflow_lite_support/python/test/task/audio/core/audio_record_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/core/audio_record_test.py
@@ -14,8 +14,8 @@
 """Tests for audio_record."""
 
 import numpy as np
-
 import tensorflow as tf
+
 from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio.core import audio_record
 

--- a/tensorflow_lite_support/python/test/task/audio/core/audio_record_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/core/audio_record_test.py
@@ -13,27 +13,27 @@
 # limitations under the License.
 """Tests for audio_record."""
 
-from unittest import mock
-
 import numpy as np
-from numpy import testing
 
-import unittest
+import tensorflow as tf
+from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio.core import audio_record
+
+_mock = test.mock
 
 _CHANNELS = 2
 _SAMPLING_RATE = 16000
 _BUFFER_SIZE = 15600
 
 
-class AudioRecordTest(unittest.TestCase):
+class AudioRecordTest(tf.test.TestCase):
 
   def setUp(self):
     super().setUp()
 
     # Mock sounddevice.InputStream
-    with mock.patch("sounddevice.InputStream") as mock_input_stream_new_method:
-      self.mock_input_stream = mock.MagicMock()
+    with _mock.patch("sounddevice.InputStream") as mock_input_stream_new_method:
+      self.mock_input_stream = _mock.MagicMock()
       mock_input_stream_new_method.return_value = self.mock_input_stream
       self.record = audio_record.AudioRecord(_CHANNELS, _SAMPLING_RATE,
                                              _BUFFER_SIZE)
@@ -72,13 +72,13 @@ class AudioRecordTest(unittest.TestCase):
 
     # Assert read data of a single chunk.
     recorded_audio_data = self.record.read(chunk_size)
-    testing.assert_almost_equal(recorded_audio_data, input_data[-1])
+    self.assertAllClose(recorded_audio_data, input_data[-1])
 
     # Assert read all data in buffer.
     recorded_audio_data = self.record.read(chunk_size * 2)
     print(input_data[-2].shape)
     expected_data = np.concatenate(input_data[-2:])
-    testing.assert_almost_equal(recorded_audio_data, expected_data)
+    self.assertAllClose(recorded_audio_data, expected_data)
 
   def test_read_fails_with_invalid_sample_size(self):
     callback_fn = self.init_args["callback"]
@@ -93,4 +93,4 @@ class AudioRecordTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-  unittest.main()
+  tf.test.main()

--- a/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for tensor_audio."""
-from absl.testing import parameterized
 import numpy as np
-
 import tensorflow as tf
+
+from absl.testing import parameterized
 from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio.core import audio_record
 from tensorflow_lite_support.python.task.audio.core import tensor_audio

--- a/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
@@ -14,23 +14,23 @@
 """Tests for tensor_audio."""
 from absl.testing import parameterized
 import numpy as np
-from numpy import testing
 
-import unittest
+import tensorflow as tf
+from tensorflow.python.platform import test
 from tensorflow_lite_support.python.task.audio.core import audio_record
 from tensorflow_lite_support.python.task.audio.core import tensor_audio
 from tensorflow_lite_support.python.task.audio.core.pybinds import _pywrap_audio_buffer
 from tensorflow_lite_support.python.test import test_util
 
 _CppAudioFormat = _pywrap_audio_buffer.AudioFormat
-_mock = unittest.mock
+_mock = test.mock
 
 _CHANNELS = 1
 _SAMPLE_RATE = 16000
 _BUFFER_SIZE = 15600
 
 
-class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
+class TensorAudioTest(parameterized.TestCase, tf.test.TestCase):
 
   def setUp(self):
     super().setUp()
@@ -69,7 +69,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    testing.assert_almost_equal(audio_buffer, array)
+    self.assertAllClose(audio_buffer, array)
 
   def test_load_from_array_succeeds_with_larger_input_size_and_default_params(
       self):
@@ -84,7 +84,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    testing.assert_almost_equal(audio_buffer, array[_BUFFER_SIZE:])
+    self.assertAllClose(audio_buffer, array[_BUFFER_SIZE:])
 
   @parameterized.parameters((0, 15600), (7800, 15600))
   def test_load_from_array_succeeds_with_larger_input_size_and_params_specified(
@@ -100,7 +100,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    testing.assert_almost_equal(audio_buffer, array[offset:offset + size])
+    self.assertAllClose(audio_buffer, array[offset:offset + size])
 
   def test_load_from_array_succeeds_with_smaller_input_size_and_default_params(
       self):
@@ -116,7 +116,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    testing.assert_almost_equal(audio_buffer[-input_length:], array)
+    self.assertAllClose(audio_buffer[-input_length:], array)
 
   @parameterized.parameters((0, 4000), (3900, 100))
   def test_load_from_array_succeeds_with_smaller_input_size_and_params_specified(
@@ -132,7 +132,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    testing.assert_almost_equal(audio_buffer[-size:],
+    self.assertAllClose(audio_buffer[-size:],
                                 array[offset:offset + size])
 
   @parameterized.parameters((7800, 15600), (0, 20000))
@@ -177,7 +177,7 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
     self.test_tensor_audio.load_from_audio_record(record)
 
     # Assert read all data in the float buffer.
-    testing.assert_almost_equal(self.test_tensor_audio.buffer, expected_data)
+    self.assertAllClose(self.test_tensor_audio.buffer, expected_data)
 
   @_mock.patch("sounddevice.InputStream", return_value=_mock.MagicMock())
   def test_load_from_audio_record_fails_with_invalid_buffer_size(self, _):
@@ -213,4 +213,4 @@ class TensorAudioTest(parameterized.TestCase, unittest.TestCase):
 
 
 if __name__ == "__main__":
-  unittest.main()
+  tf.test.main()

--- a/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
+++ b/tensorflow_lite_support/python/test/task/audio/core/tensor_audio_test.py
@@ -132,8 +132,7 @@ class TensorAudioTest(parameterized.TestCase, tf.test.TestCase):
     self.assertEqual(audio_format.sample_rate, _SAMPLE_RATE)
     self.assertEqual(self.test_tensor_audio.buffer_size, _BUFFER_SIZE)
     self.assertIsInstance(audio_buffer, np.ndarray)
-    self.assertAllClose(audio_buffer[-size:],
-                                array[offset:offset + size])
+    self.assertAllClose(audio_buffer[-size:], array[offset:offset + size])
 
   @parameterized.parameters((7800, 15600), (0, 20000))
   def test_load_from_array_fails_with_invalid_offset_size(self, offset, size):

--- a/tensorflow_lite_support/python/test/task/vision/BUILD
+++ b/tensorflow_lite_support/python/test/task/vision/BUILD
@@ -33,6 +33,7 @@ py_test(
         "//tensorflow_lite_support/cc/test/testdata/task/vision:test_models",
     ],
     deps = [
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/core/proto:base_options_py_pb2",
         "//tensorflow_lite_support/python/task/processor/proto:bounding_box_pb2",
         "//tensorflow_lite_support/python/task/processor/proto:class_pb2",
@@ -74,6 +75,7 @@ py_test(
         "//tensorflow_lite_support/cc/test/testdata/task/vision:test_models",
     ],
     deps = [
+        # build rule placeholder: tensorflow dep,
         "//tensorflow_lite_support/python/task/core/proto:base_options_py_pb2",
         "//tensorflow_lite_support/python/task/processor/proto:bounding_box_pb2",
         "//tensorflow_lite_support/python/task/processor/proto:class_pb2",

--- a/tensorflow_lite_support/python/test/task/vision/core/BUILD
+++ b/tensorflow_lite_support/python/test/task/vision/core/BUILD
@@ -1,0 +1,23 @@
+# Placeholder for internal Python strict test compatibility macro.
+
+package(
+    default_visibility = ["//tensorflow_lite_support:internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+py_test(
+    name = "tensor_image_test",
+    srcs = ["tensor_image_test.py"],
+    data = [
+        "//tensorflow_lite_support/cc/test/testdata/task/vision:test_images",
+    ],
+    deps = [
+        # build rule placeholder: numpy dep,
+        # build rule placeholder: tensorflow dep,
+        "//tensorflow_lite_support/python/task/vision/core:color_space_type",
+        "//tensorflow_lite_support/python/task/vision/core:tensor_image",
+        "//tensorflow_lite_support/python/task/vision/core/pybinds:image_utils",
+        "//tensorflow_lite_support/python/test:test_util",
+        "@absl_py//absl/testing:parameterized",
+    ],
+)

--- a/tensorflow_lite_support/python/test/task/vision/core/tensor_image_test.py
+++ b/tensorflow_lite_support/python/test/task/vision/core/tensor_image_test.py
@@ -51,7 +51,7 @@ class TensorImageTest(tf.test.TestCase, parameterized.TestCase):
     self.assertEqual(image.width, width)
     self.assertEqual(image.color_space_type, color_type)
     self.assertIsInstance(image.buffer, np.ndarray)
-    self.assertAllEqual(image.buffer, array)
+    self.assertAllClose(image.buffer, array)
 
 
 if __name__ == '__main__':

--- a/tensorflow_lite_support/python/test/task/vision/image_classifier_test.py
+++ b/tensorflow_lite_support/python/test/task/vision/image_classifier_test.py
@@ -15,12 +15,11 @@
 
 import enum
 import json
+import tensorflow as tf
 
 from absl.testing import parameterized
 from google.protobuf import json_format
-# TODO(b/220067158): Change to import tensorflow and leverage tf.test once
-# fixed the dependency issue.
-import unittest
+
 from tensorflow_lite_support.python.task.core.proto import base_options_pb2
 from tensorflow_lite_support.python.task.processor.proto import bounding_box_pb2
 from tensorflow_lite_support.python.task.processor.proto import class_pb2
@@ -142,7 +141,7 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
       base_options = _BaseOptions(file_content=model_content)
     else:
       # Should never happen
-      raise ValueError('model_file_type is invalid.')
+      raise ValueError("model_file_type is invalid.")
 
     classifier = _create_classifier_from_options(
         base_options, max_results=max_results)
@@ -217,7 +216,7 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
     categories = image_result_dict['classifications'][0]['classes']
 
     self.assertLessEqual(
-        len(categories), _MAX_RESULTS, 'Too many results returned.')
+        len(categories), _MAX_RESULTS, "Too many results returned.")
 
   def test_score_threshold_option(self):
     # Creates classifier.
@@ -239,8 +238,7 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
       score = category['score']
       self.assertGreaterEqual(
           score, _SCORE_THRESHOLD,
-          'Classification with score lower than threshold found. {0}'.format(
-              category))
+          f"Classification with score lower than threshold found. {category}")
 
   def test_allowlist_option(self):
     # Creates classifier.
@@ -262,7 +260,7 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
       label = category['className']
       self.assertIn(
           label, _ALLOW_LIST,
-          'Label "{0}" found but not in label allow list'.format(label))
+          f"Label {label} found but not in label allow list")
 
   def test_denylist_option(self):
     # Creates classifier.
@@ -283,14 +281,14 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
     for category in categories:
       label = category['className']
       self.assertNotIn(label, _DENY_LIST,
-                       'Label "{0}" found but in deny list.'.format(label))
+                       f"Label {label} found but in deny list.")
 
   def test_combined_allowlist_and_denylist(self):
     # Fails with combined allowlist and denylist
     with self.assertRaisesRegex(
         ValueError,
-        r'`class_name_whitelist` and `class_name_blacklist` are mutually '
-        r'exclusive options.'):
+        r"`class_name_whitelist` and `class_name_blacklist` are mutually "
+        r"exclusive options."):
       base_options = _BaseOptions(file_name=self.model_path)
       classification_options = classification_options_pb2.ClassificationOptions(
           class_name_allowlist=['foo'], class_name_denylist=['bar'])
@@ -301,4 +299,4 @@ class ImageClassifierTest(parameterized.TestCase, base_test.BaseTestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  tf.test.main()

--- a/tensorflow_lite_support/python/test/task/vision/object_detector_test.py
+++ b/tensorflow_lite_support/python/test/task/vision/object_detector_test.py
@@ -15,12 +15,10 @@
 
 import enum
 import json
+import tensorflow as tf
 
 from absl.testing import parameterized
-# TODO(b/220067158): Change to import tensorflow and leverage tf.test once
-# fixed the dependency issue.
 from google.protobuf import json_format
-import unittest
 from tensorflow_lite_support.python.task.core.proto import base_options_pb2
 from tensorflow_lite_support.python.task.processor.proto import bounding_box_pb2
 from tensorflow_lite_support.python.task.processor.proto import class_pb2
@@ -167,7 +165,7 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
       base_options = _BaseOptions(file_content=model_content)
     else:
       # Should never happen
-      raise ValueError('model_file_type is invalid.')
+      raise ValueError("model_file_type is invalid.")
 
     detector = _create_detector_from_options(
         base_options, max_results=max_results)
@@ -205,8 +203,7 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
       score = category['classes'][0]['score']
       self.assertGreaterEqual(
           score, _SCORE_THRESHOLD,
-          'Classification with score lower than threshold found. {0}'.format(
-              category))
+          f"Classification with score lower than threshold found. {category}")
 
   def test_max_results_option(self):
     # Creates detector.
@@ -223,7 +220,7 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
     detections = image_result_dict['detections']
 
     self.assertLessEqual(
-        len(detections), _MAX_RESULTS, 'Too many results returned.')
+        len(detections), _MAX_RESULTS, "Too many results returned.")
 
   def test_allow_list_option(self):
     # Creates detector.
@@ -244,7 +241,7 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
       label = category['classes'][0]['className']
       self.assertIn(
           label, _ALLOW_LIST,
-          'Label "{0}" found but not in label allow list'.format(label))
+          f"Label {label} found but not in label allow list")
 
   def test_deny_list_option(self):
     # Creates detector.
@@ -264,14 +261,14 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
     for category in categories:
       label = category['classes'][0]['className']
       self.assertNotIn(label, _DENY_LIST,
-                       'Label "{0}" found but in deny list.'.format(label))
+                       f"Label {label} found but in deny list.")
 
   def test_combined_allowlist_and_denylist(self):
     # Fails with combined allowlist and denylist
     with self.assertRaisesRegex(
         ValueError,
-        r'`class_name_whitelist` and `class_name_blacklist` are mutually '
-        r'exclusive options.'):
+        r"`class_name_whitelist` and `class_name_blacklist` are mutually "
+        r"exclusive options."):
       base_options = _BaseOptions(file_name=self.model_path)
       detection_options = detection_options_pb2.DetectionOptions(
           class_name_allowlist=['foo'], class_name_denylist=['bar'])
@@ -281,4 +278,4 @@ class ObjectDetectorTest(parameterized.TestCase, base_test.BaseTestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  tf.test.main()


### PR DESCRIPTION
- Updates copyright to the right year in some files of the vision tasks. 
- Migrate tests in Task Library to use `tf.test` instead of `unittest`
- Updated docstrings for Audio Task APIs' `required_audio_format` property