### PR TITLE
Documentation Updated for iOS Vision APIs

### DIFF
--- a/tensorflow_lite_support/ios/task/processor/sources/TFLClassificationResult.h
+++ b/tensorflow_lite_support/ios/task/processor/sources/TFLClassificationResult.h
@@ -32,11 +32,10 @@ NS_SWIFT_NAME(Classifications)
 @property(nonatomic, readonly) NSArray<TFLCategory *> *categories;
 
 /**
- * Initializes TFLClassifications.
+ * Initializes a new instance of TFLClassifications.
  *
  * @param categories Array of TFLCategory objects encapsulating a list of
  * predictions usually sorted by descending scores (e.g. from high to low probability).
- * @seealso TFLCategory
  *
  * @return An instance of TFLClassifications initialized to
  * the specified values.
@@ -60,7 +59,6 @@ NS_SWIFT_NAME(ClassificationResult)
  *
  * @param classifications Array of TFLClassifications objects containing image classifier
  * predictions per image classifier head.
- * @seealso TFLClassifications
  *
  * @return An instance of TFLClassificationResult initialized to the specified values.
  */

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
@@ -29,26 +29,29 @@ NS_SWIFT_NAME(ImageClassifierOptions)
 
 /**
  * Base options that are used for creation of any type of task.
+ * @discussion Please see `TFLBaseOptions` for more details.
  */
 @property(nonatomic, copy) TFLBaseOptions *baseOptions;
 
 /**
  * Options that configure the display and filtering of results.
+ * @discussion Please see `TFLClassificationOptions` for more details.
  */
 @property(nonatomic, copy) TFLClassificationOptions *classificationOptions;
 
 /**
- * Initializes TFLImageClassifierOptions with the specified model path that points to a model file.
+ * Initializes a new `TFLImageClassifierOptions` with the absolute path to the model file 
+ * stored locally on the device, set to the given the model path.
  * 
  * @discussion The external model file, must be a single standalone TFLite file. It could be packed
  * with TFLite Model Metadata[1] and associated files if exist. Fail to provide the necessary
  * metadata and associated files might result in errors. Check the [documentation]
  * (https://www.tensorflow.org/lite/convert/metadata) for each task about the specific requirement.
  *
- * @param modelPath Path to a TFLite model file.
+ * @param modelPath An absolute path to a TensorFlow Lite model file stored locally on the device.
  *
- * @return An instance of TFLImageClassifierOptions set to the specified
- * modelPath.
+ * @return An new instance of `TFLImageClassifierOptions` set to the given
+ * model path.
  */
 - (instancetype)initWithModelPath:(NSString *)modelPath;
 
@@ -93,6 +96,7 @@ NS_SWIFT_NAME(ImageClassifier)
  * @param image An image to be classified, represented as a `GMLImage`.
  *
  * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if there is an error encountered during classification.
+ * Please see `TFLClassificationResult` for more details.
  */
 - (nullable TFLClassificationResult *)classifyWithGMLImage:(GMLImage *)image
                                                      error:(NSError *_Nullable *)error

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
@@ -40,9 +40,9 @@ NS_SWIFT_NAME(ImageClassifierOptions)
 @property(nonatomic, copy) TFLClassificationOptions *classificationOptions;
 
 /**
- * Initializes a new `TFLImageClassifierOptions` with the absolute path to the model file 
+ * Initializes a new `TFLImageClassifierOptions` with the absolute path to the model file
  * stored locally on the device, set to the given the model path.
- * 
+ *
  * @discussion The external model file, must be a single standalone TFLite file. It could be packed
  * with TFLite Model Metadata[1] and associated files if exist. Fail to provide the necessary
  * metadata and associated files might result in errors. Check the [documentation]
@@ -73,8 +73,9 @@ NS_SWIFT_NAME(ImageClassifier)
  * @param options Options to use for configuring the `TFLImageClassifier`.
  * @param error An optional error parameter populated when there is an error in initializing
  * the image classifier.
- *  
- * @return A new instance of `TFLImageClassifier` with the given options. `nil` if there is an error in initializing the image classifier.
+ *
+ * @return A new instance of `TFLImageClassifier` with the given options. `nil` if there is an error
+ * in initializing the image classifier.
  */
 + (nullable instancetype)imageClassifierWithOptions:(TFLImageClassifierOptions *)options
                                               error:(NSError **)error
@@ -83,8 +84,8 @@ NS_SWIFT_NAME(ImageClassifier)
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Performs classification on the given GMLImage. 
- * 
+ * Performs classification on the given GMLImage.
+ *
  * @discussion This method currently supports classification of only the following types of images:
  * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
  * 2. kCVPixelFormatType_32BGRA for `GMLImageSourceTypePixelBuffer` and
@@ -95,15 +96,17 @@ NS_SWIFT_NAME(ImageClassifier)
  *
  * @param image An image to be classified, represented as a `GMLImage`.
  *
- * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if there is an error encountered during classification.
- * Please see `TFLClassificationResult` for more details.
+ * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if
+ * there is an error encountered during classification. Please see `TFLClassificationResult` for
+ * more details.
  */
 - (nullable TFLClassificationResult *)classifyWithGMLImage:(GMLImage *)image
                                                      error:(NSError *_Nullable *)error
     NS_SWIFT_NAME(classify(gmlImage:));
 
 /**
- * Performs classification on the pixels within the specified region of interest of the given `GMLImage`.
+ * Performs classification on the pixels within the specified region of interest of the given
+ * `GMLImage`.
  *
  * @discussion This method currently supports inference on only following type of images:
  * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
@@ -114,9 +117,11 @@ NS_SWIFT_NAME(ImageClassifier)
  *    results will be wrong.
  *
  * @param image An image to be classified, represented as a `GMLImage`.
- * @param roi A CGRect specifying the region of interest within the given `GMLImage`, on which classification should be performed.
+ * @param roi A CGRect specifying the region of interest within the given `GMLImage`, on which
+ * classification should be performed.
  *
- * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if there is an error encountered during classification.
+ * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if
+ * there is an error encountered during classification.
  */
 - (nullable TFLClassificationResult *)classifyWithGMLImage:(GMLImage *)image
                                           regionOfInterest:(CGRect)roi

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLImageClassifier.h
@@ -28,21 +28,19 @@ NS_SWIFT_NAME(ImageClassifierOptions)
 @interface TFLImageClassifierOptions : NSObject
 
 /**
- * Base options that is used for creation of any type of task.
- * @seealso TFLBaseOptions
+ * Base options that are used for creation of any type of task.
  */
 @property(nonatomic, copy) TFLBaseOptions *baseOptions;
 
 /**
  * Options that configure the display and filtering of results.
- * @seealso TFLClassificationOptions
  */
 @property(nonatomic, copy) TFLClassificationOptions *classificationOptions;
 
 /**
- * Initializes TFLImageClassifierOptions with the model path set to the specified path to a model
- * file.
- * @description The external model file, must be a single standalone TFLite file. It could be packed
+ * Initializes TFLImageClassifierOptions with the specified model path that points to a model file.
+ * 
+ * @discussion The external model file, must be a single standalone TFLite file. It could be packed
  * with TFLite Model Metadata[1] and associated files if exist. Fail to provide the necessary
  * metadata and associated files might result in errors. Check the [documentation]
  * (https://www.tensorflow.org/lite/convert/metadata) for each task about the specific requirement.
@@ -67,12 +65,13 @@ NS_SWIFT_NAME(ImageClassifier)
 @interface TFLImageClassifier : NSObject
 
 /**
- * Creates TFLImageClassifier from a model file and specified options .
+ * Initializes a new instance of `TFLImageClassifier` from the given `TFLImageClassifierOptions`.
  *
- * @param options TFLImageClassifierOptions instance with the necessary
- * properties set.
- *
- * @return A TFLImageClassifier instance.
+ * @param options Options to use for configuring the `TFLImageClassifier`.
+ * @param error An optional error parameter populated when there is an error in initializing
+ * the image classifier.
+ *  
+ * @return A new instance of `TFLImageClassifier` with the given options. `nil` if there is an error in initializing the image classifier.
  */
 + (nullable instancetype)imageClassifierWithOptions:(TFLImageClassifierOptions *)options
                                               error:(NSError **)error
@@ -81,42 +80,39 @@ NS_SWIFT_NAME(ImageClassifier)
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Performs classification on a GMLImage input, returns an array of
- * categorization results where each member in the array is an array of
- * TFLClass objects for each classification head.
- * This method currently supports inference on only following type of images:
- * 1. RGB and RGBA images for GMLImageSourceTypeImage.
- * 2. kCVPixelFormatType_32BGRA for GMLImageSourceTypePixelBuffer and
- *    GMLImageSourceTypeSampleBuffer. If you are using AVCaptureSession to setup
+ * Performs classification on the given GMLImage. 
+ * 
+ * @discussion This method currently supports classification of only the following types of images:
+ * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
+ * 2. kCVPixelFormatType_32BGRA for `GMLImageSourceTypePixelBuffer` and
+ *    `GMLImageSourceTypeSampleBuffer`. If you are using `AVCaptureSession` to setup
  *    camera and get the frames for inference, you must request for this format
  *    from AVCaptureVideoDataOutput. Otherwise your classification
  *    results will be wrong.
  *
- * @param image input to the model.
+ * @param image An image to be classified, represented as a `GMLImage`.
  *
- * @return An NSArray<NSArray<TFLClass *>*> * of classification results.
+ * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if there is an error encountered during classification.
  */
 - (nullable TFLClassificationResult *)classifyWithGMLImage:(GMLImage *)image
                                                      error:(NSError *_Nullable *)error
     NS_SWIFT_NAME(classify(gmlImage:));
 
 /**
- * Performs classification on a GMLImage input on the pixels in the
- * specified bounding box, returns an array of categorization results
- * where each member in the array is an array of TFLClass objects for
- * each classification head.
- * This method currently supports inference on only following type of images:
- * 1. RGB and RGBA images for GMLImageSourceTypeImage.
- * 2. kCVPixelFormatType_32BGRA for GMLImageSourceTypePixelBuffer and
- *    GMLImageSourceTypeSampleBuffer. If you are using AVCaptureSession to setup
+ * Performs classification on the pixels within the specified region of interest of the given `GMLImage`.
+ *
+ * @discussion This method currently supports inference on only following type of images:
+ * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
+ * 2. kCVPixelFormatType_32BGRA for `GMLImageSourceTypePixelBuffer` and
+ *    `GMLImageSourceTypeSampleBuffer`. If you are using `AVCaptureSession` to setup
  *    camera and get the frames for inference, you must request for this format
  *    from AVCaptureVideoDataOutput. Otherwise your classification
  *    results will be wrong.
  *
- * @param image input to the model.
- * @param roi CGRect specifying region of interest in image.
+ * @param image An image to be classified, represented as a `GMLImage`.
+ * @param roi A CGRect specifying the region of interest within the given `GMLImage`, on which classification should be performed.
  *
- * @return An NSArray<NSArray<TFLClass *>*> * of classification results.
+ * @return A TFLClassificationResult with one set of results per image classifier head. `nil` if there is an error encountered during classification.
  */
 - (nullable TFLClassificationResult *)classifyWithGMLImage:(GMLImage *)image
                                           regionOfInterest:(CGRect)roi

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLImageSegmenter.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLImageSegmenter.h
@@ -20,11 +20,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Specifies the type of output segmentation mask to be returned as a result
- * of the image segmentation operation. This allows specifying the type of
- * post-processing to perform on the raw model results
- *
- * @seealso TfLiteSegmentationResult for more.
+ * Specifies the type of the output segmentation mask to be returned as the result
+ * of the image segmentation operation. This directs the `TFLImageSegmenter` to
+ * choose the type of post-processing to be performed on the raw model results.
  */
 typedef NS_ENUM(NSUInteger, TFLOutputType) {
   /** Unspecified output type. */
@@ -45,40 +43,42 @@ typedef NS_ENUM(NSUInteger, TFLOutputType) {
 } NS_SWIFT_NAME(OutputType);
 
 /**
- * Options to configure TFLImageSegmenter.
+ * Options to configure `TFLImageSegmenter`.
  */
 NS_SWIFT_NAME(ImageSegmenterOptions)
 @interface TFLImageSegmenterOptions : NSObject
 
 /**
  * Base options that is used for creation of any type of task.
- * @seealso TFLBaseOptions
+ * @discussion Please see `TFLBaseOptions` for more details.
  */
 @property(nonatomic, copy) TFLBaseOptions *baseOptions;
 
 /**
  * Specifies the type of output segmentation mask to be returned as a result
  * of the image segmentation operation.
- * @seealso TFLOutputType
  */
 @property(nonatomic) TFLOutputType outputType;
 
-/** Display names local for display names*/
+/** 
+ * Display names local for display names
+ */
 @property(nonatomic, copy) NSString *displayNamesLocale;
 
 /**
- * Initializes TFLImageSegmenterOptions with the model path set to the specified
- * path to a model file.
- * @description The external model file, must be a single standalone TFLite
+ * Initializes a new `TFLImageSegmenterOptions` with the absolute path to the model file 
+ * stored locally on the device, set to the given the model path.
+ * .
+ * @discussion The external model file, must be a single standalone TFLite
  * file. It could be packed with TFLite Model Metadata[1] and associated files
  * if exist. Fail to provide the necessary metadata and associated files might
  * result in errors. Check the [documentation](https://www.tensorflow.org/lite/convert/metadata)
  * for each task about the specific requirement.
  *
- * @param modelPath Path to a TFLite model file.
+ * @param modelPath An absolute path to a TensorFlow Lite model file stored locally on the device.
  *
- * @return An instance of TFLImageSegmenterOptions set to the specified
- * modelPath.
+ * @return An new instance of `TFLImageSegmenterOptions` set to the given
+ * model path.
  */
 - (instancetype)initWithModelPath:(NSString *)modelPath;
 
@@ -88,12 +88,13 @@ NS_SWIFT_NAME(ImageSegmenter)
 @interface TFLImageSegmenter : NSObject
 
 /**
- * Creates TFLImageSegmenter from a model file and specified options .
+ * Initializes a new instance of `TFLImageSegmenter` from the given `TFLImageSegmenterOptions`.
  *
- * @param options TFLImageSegmenterOptions instance with the necessary
- * properties set.
- *
- * @return A TFLImageSegmenter instance.
+ * @param options Options to use for configuring the `TFLImageSegmenter`.
+ * @param error An optional error parameter populated when there is an error in initializing
+ * the image segmenter.
+ *  
+ * @return A new instance of `TFLImageSegmenter` with the given options. `nil` if there is an error in initializing the image segmenter.
  */
 + (nullable instancetype)imageSegmenterWithOptions:(nonnull TFLImageSegmenterOptions *)options
                                              error:(NSError **)error
@@ -102,20 +103,20 @@ NS_SWIFT_NAME(ImageSegmenter)
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Performs image segmentation on a GMLImage input, returns the segmentation
- * results.
- * This method currently supports inference on only following type of images:
- * 1. RGB and RGBA images for GMLImageSourceTypeImage.
- * 2. kCVPixelFormatType_32BGRA for GMLImageSourceTypePixelBuffer and
- *    GMLImageSourceTypeSampleBuffer. If you are using AVCaptureSession to setup
+ * Performs segmentation on the given GMLImage.
+ * 
+ * @discussion This method currently supports segmentation of only the following types of images:
+ * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
+ * 2. kCVPixelFormatType_32BGRA for `GMLImageSourceTypePixelBuffer` and
+ *    `GMLImageSourceTypeSampleBuffer`. If you are using `AVCaptureSession` to setup
  *    camera and get the frames for inference, you must request for this format
- *    from AVCaptureVideoDataOutput. Otherwise your classification
+ *    from AVCaptureVideoDataOutput. Otherwise your segmentation
  *    results will be wrong.
  *
- * @param image input to the model.
+ * @param image An image to be segmented, represented as a `GMLImage`.
  *
- * @return Segmentation Result of type TFLSegmentationResult holds the
- * segmentation masks returned by the image segmentation task.
+ * @return A TFLSegmentationResult that holds the segmentation masks returned by the image segmentation task. `nil` if there is an error encountered during segmentation.
+ * Please see `TFLSegmentationResult` for more details.
  */
 - (nullable TFLSegmentationResult *)segmentWithGMLImage:(GMLImage *)image
                                                   error:(NSError *_Nullable *)error

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLImageSegmenter.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLImageSegmenter.h
@@ -60,13 +60,13 @@ NS_SWIFT_NAME(ImageSegmenterOptions)
  */
 @property(nonatomic) TFLOutputType outputType;
 
-/** 
+/**
  * Display names local for display names
  */
 @property(nonatomic, copy) NSString *displayNamesLocale;
 
 /**
- * Initializes a new `TFLImageSegmenterOptions` with the absolute path to the model file 
+ * Initializes a new `TFLImageSegmenterOptions` with the absolute path to the model file
  * stored locally on the device, set to the given the model path.
  * .
  * @discussion The external model file, must be a single standalone TFLite
@@ -93,8 +93,9 @@ NS_SWIFT_NAME(ImageSegmenter)
  * @param options Options to use for configuring the `TFLImageSegmenter`.
  * @param error An optional error parameter populated when there is an error in initializing
  * the image segmenter.
- *  
- * @return A new instance of `TFLImageSegmenter` with the given options. `nil` if there is an error in initializing the image segmenter.
+ *
+ * @return A new instance of `TFLImageSegmenter` with the given options. `nil` if there is an error
+ * in initializing the image segmenter.
  */
 + (nullable instancetype)imageSegmenterWithOptions:(nonnull TFLImageSegmenterOptions *)options
                                              error:(NSError **)error
@@ -104,7 +105,7 @@ NS_SWIFT_NAME(ImageSegmenter)
 
 /**
  * Performs segmentation on the given GMLImage.
- * 
+ *
  * @discussion This method currently supports segmentation of only the following types of images:
  * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
  * 2. kCVPixelFormatType_32BGRA for `GMLImageSourceTypePixelBuffer` and
@@ -115,8 +116,9 @@ NS_SWIFT_NAME(ImageSegmenter)
  *
  * @param image An image to be segmented, represented as a `GMLImage`.
  *
- * @return A TFLSegmentationResult that holds the segmentation masks returned by the image segmentation task. `nil` if there is an error encountered during segmentation.
- * Please see `TFLSegmentationResult` for more details.
+ * @return A TFLSegmentationResult that holds the segmentation masks returned by the image
+ * segmentation task. `nil` if there is an error encountered during segmentation. Please see
+ * `TFLSegmentationResult` for more details.
  */
 - (nullable TFLSegmentationResult *)segmentWithGMLImage:(GMLImage *)image
                                                   error:(NSError *_Nullable *)error

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLObjectDetector.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLObjectDetector.h
@@ -21,34 +21,35 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Options to configure TFLObjectDetector.
+ * Options to configure `TFLObjectDetector`.
  */
 NS_SWIFT_NAME(ObjectDetectorOptions)
 @interface TFLObjectDetectorOptions : NSObject
 
 /**
  * Base options that is used for creation of any type of task.
- * @seealso TFLBaseOptions
+ * @discussion Please see `TFLBaseOptions` for more details.
  */
 @property(nonatomic, copy) TFLBaseOptions *baseOptions;
 
 /**
  * Options that configure the display and filtering of results.
- * @seealso TFLClassificationOptions
+ * @discussion Please see `TFLClassificationOptions` for more details.
  */
 @property(nonatomic, copy) TFLClassificationOptions *classificationOptions;
 
 /**
- * Initializes TFLObjectDetectorOptions with the model path set to the specified path to a model
- * file.
- * @description The external model file, must be a single standalone TFLite file. It could be packed
+ * Initializes a new `TFLObjectDetectorOptions` with the absolute path to the model file 
+ * stored locally on the device, set to the given the model path.
+ * 
+ * @discussion The external model file, must be a single standalone TFLite file. It could be packed
  * with TFLite Model Metadata[1] and associated files if exist. Fail to provide the necessary
  * metadata and associated files might result in errors. Check the [documentation]
  * (https://www.tensorflow.org/lite/convert/metadata) for each task about the specific requirement.
  *
- * @param modelPath Path to a TFLite model file.
- * @return An instance of TFLObjectDetectorOptions set to the specified
- * modelPath.
+ * @param modelPath An absolute path to a TensorFlow Lite model file stored locally on the device.
+ * @return An new instance of `TFLObjectDetectorOptions` set to the given
+ * model path.
  */
 - (instancetype)initWithModelPath:(NSString *)modelPath;
 
@@ -58,12 +59,13 @@ NS_SWIFT_NAME(ObjectDetector)
 @interface TFLObjectDetector : NSObject
 
 /**
- * Creates TFLObjectDetector from a model file and specified options .
+ * Initializes a new instance of `TFLObjectDetector` from the given `TFLObjectDetectorOptions`.
  *
- * @param options TFLObjectDetectorOptions instance with the necessary
- * properties set.
- *
- * @return A TFLObjectDetector instance.
+ * @param options Options to use for configuring the `TFLObjectDetector`.
+ * @param error An optional error parameter populated when there is an error in initializing
+ * the object detector.
+ *  
+ * @return A new instance of `TFLObjectDetector` with the given options. `nil` if there is an error in initializing the object detector.
  */
 + (nullable instancetype)objectDetectorWithOptions:(TFLObjectDetectorOptions *)options
                                              error:(NSError **)error
@@ -72,19 +74,19 @@ NS_SWIFT_NAME(ObjectDetector)
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Performs object detection on a GMLImage input, returns the detected objects in the image.
- * This method currently supports inference on only following type of images:
- * 1. RGB and RGBA images for GMLImageSourceTypeImage.
- * 2. kCVPixelFormatType_32BGRA for GMLImageSourceTypePixelBuffer and
- *    GMLImageSourceTypeSampleBuffer. If you are using AVCaptureSession to setup
+ * Performs object detection on the given GMLImage.
+ * @discussion This method currently supports object detection on only the following types of images:
+ * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
+ * 2. `kCVPixelFormatType_32BGRA` for `GMLImageSourceTypePixelBuffer` and
+ *    `GMLImageSourceTypeSampleBuffer`. If you are using `AVCaptureSession` to setup
  *    camera and get the frames for inference, you must request for this format
- *    from AVCaptureVideoDataOutput. Otherwise your classification
+ *    from AVCaptureVideoDataOutput. Otherwise your object detection
  *    results will be wrong.
  *
- * @param image input to the model.
- * @return Detection Result of type TFLDetectionResult an array of
- * detected objeects  where each detected object has a bounding box and an array of TFLCategory
- * holding the predicted classes for the detected object.
+ * @param image An image on which object detection is to be performed, represented as a `GMLImage`.
+ * 
+ * @return A `TFLDetectionResult` holding an array of TFLDetection objects, each having a bounding box specifying the region the were detected in and an array of predicted classes.
+ * Please see `TFLDetectionResult` for more details.
  */
 - (nullable TFLDetectionResult *)detectWithGMLImage:(GMLImage *)image
                                               error:(NSError *_Nullable *)error

--- a/tensorflow_lite_support/ios/task/vision/sources/TFLObjectDetector.h
+++ b/tensorflow_lite_support/ios/task/vision/sources/TFLObjectDetector.h
@@ -39,9 +39,9 @@ NS_SWIFT_NAME(ObjectDetectorOptions)
 @property(nonatomic, copy) TFLClassificationOptions *classificationOptions;
 
 /**
- * Initializes a new `TFLObjectDetectorOptions` with the absolute path to the model file 
+ * Initializes a new `TFLObjectDetectorOptions` with the absolute path to the model file
  * stored locally on the device, set to the given the model path.
- * 
+ *
  * @discussion The external model file, must be a single standalone TFLite file. It could be packed
  * with TFLite Model Metadata[1] and associated files if exist. Fail to provide the necessary
  * metadata and associated files might result in errors. Check the [documentation]
@@ -64,8 +64,9 @@ NS_SWIFT_NAME(ObjectDetector)
  * @param options Options to use for configuring the `TFLObjectDetector`.
  * @param error An optional error parameter populated when there is an error in initializing
  * the object detector.
- *  
- * @return A new instance of `TFLObjectDetector` with the given options. `nil` if there is an error in initializing the object detector.
+ *
+ * @return A new instance of `TFLObjectDetector` with the given options. `nil` if there is an error
+ * in initializing the object detector.
  */
 + (nullable instancetype)objectDetectorWithOptions:(TFLObjectDetectorOptions *)options
                                              error:(NSError **)error
@@ -75,7 +76,8 @@ NS_SWIFT_NAME(ObjectDetector)
 
 /**
  * Performs object detection on the given GMLImage.
- * @discussion This method currently supports object detection on only the following types of images:
+ * @discussion This method currently supports object detection on only the following types of
+ * images:
  * 1. RGB and RGBA images for `GMLImageSourceTypeImage`.
  * 2. `kCVPixelFormatType_32BGRA` for `GMLImageSourceTypePixelBuffer` and
  *    `GMLImageSourceTypeSampleBuffer`. If you are using `AVCaptureSession` to setup
@@ -84,9 +86,10 @@ NS_SWIFT_NAME(ObjectDetector)
  *    results will be wrong.
  *
  * @param image An image on which object detection is to be performed, represented as a `GMLImage`.
- * 
- * @return A `TFLDetectionResult` holding an array of TFLDetection objects, each having a bounding box specifying the region the were detected in and an array of predicted classes.
- * Please see `TFLDetectionResult` for more details.
+ *
+ * @return A `TFLDetectionResult` holding an array of TFLDetection objects, each having a bounding
+ * box specifying the region the were detected in and an array of predicted classes. Please see
+ * `TFLDetectionResult` for more details.
  */
 - (nullable TFLDetectionResult *)detectWithGMLImage:(GMLImage *)image
                                               error:(NSError *_Nullable *)error


### PR DESCRIPTION
1. Updated documentation of vision APIs to fix inconsistencies.
2. Removed @seealso since they don't show up properly when viewed from Xcode.