### PR TITLE
Comment out TODO in Readme

### DIFF
--- a/tensorflow_lite_support/examples/task/text/desktop/README.md
+++ b/tensorflow_lite_support/examples/task/text/desktop/README.md
@@ -93,7 +93,7 @@ category[1]: 'Positive' : '0.18687'
 
 #### Prerequisites
 
-TODO(b/163086702): Update the links to models with metadata attached.
+<!-- TODO(b/163086702): Update the links to models with metadata attached. -->
 
 You will need:
 


### PR DESCRIPTION
The link to the bug shows up in the Readme section for the examples, which is a bit strange.