### PR TITLE
Fixed On Device Memory Issue

### DIFF
--- a/tensorflow_lite_support/ios/task/audio/sources/TFLAudioClassifier.m
+++ b/tensorflow_lite_support/ios/task/audio/sources/TFLAudioClassifier.m
@@ -155,7 +155,6 @@
   TfLiteAudioBuffer cAudioBuffer = [audioTensor cAudioBufferFromFloatBuffer:audioTensorBuffer];
 
   TfLiteSupportError *classifyError = NULL;
-
   TfLiteClassificationResult *cClassificationResult =
       TfLiteAudioClassifierClassify(_audioClassifier, &cAudioBuffer, &classifyError);
 

--- a/tensorflow_lite_support/ios/task/audio/sources/TFLAudioClassifier.m
+++ b/tensorflow_lite_support/ios/task/audio/sources/TFLAudioClassifier.m
@@ -151,9 +151,11 @@
     return nil;
   }
 
-  TfLiteAudioBuffer cAudioBuffer = [audioTensor cAudioBufferFromFloatBuffer:audioTensor.buffer];
+  TFLFloatBuffer *audioTensorBuffer = audioTensor.buffer;
+  TfLiteAudioBuffer cAudioBuffer = [audioTensor cAudioBufferFromFloatBuffer:audioTensorBuffer];
 
   TfLiteSupportError *classifyError = NULL;
+
   TfLiteClassificationResult *cClassificationResult =
       TfLiteAudioClassifierClassify(_audioClassifier, &cAudioBuffer, &classifyError);
 


### PR DESCRIPTION
Fixed an EXC_BAD_ACCESS error which occurred on device due to early release of `audioTensor.buffer.data` before the end of 
`-[TFLAudioClassifier classifyWithAudioTensor:error:]` if it is not assigned to a local variable in the method.