### PR TITLE
Fixed iOS No: of Threads Not Being Set Issue

### DIFF
--- a/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions+Helpers.m
+++ b/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions+Helpers.m
@@ -19,7 +19,7 @@
 - (void)copyToCOptions:(TfLiteBaseOptions *)cBaseOptions {
   if (self.modelFile.filePath) {
     cBaseOptions->model_file.file_path = self.modelFile.filePath.UTF8String;
-    cBaseOptions->computeSettings.cpuSettings.num_threads = (int)self.computeSettings.cpuSettings.numThreads;
+    cBaseOptions->compute_settings.cpu_settings.num_threads = (int)self.computeSettings.cpuSettings.numThreads;
   }
 }
 

--- a/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions+Helpers.m
+++ b/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions+Helpers.m
@@ -19,6 +19,7 @@
 - (void)copyToCOptions:(TfLiteBaseOptions *)cBaseOptions {
   if (self.modelFile.filePath) {
     cBaseOptions->model_file.file_path = self.modelFile.filePath.UTF8String;
+    cBaseOptions->computeSettings.cpuSettings.num_threads = (int)self.computeSettings.cpuSettings.numThreads;
   }
 }
 

--- a/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions.h
+++ b/tensorflow_lite_support/ios/task/core/sources/TFLBaseOptions.h
@@ -24,7 +24,7 @@ NS_SWIFT_NAME(CpuSettings)
  * @discussion This property hould be greater than 0 or equal to -1. Setting  it to -1 has the
  * effect to let TFLite runtime set the value.
  */
-@property(nonatomic) int numThreads;
+@property(nonatomic) NSInteger numThreads;
 
 @end
 

--- a/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
+++ b/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
@@ -112,7 +112,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testInferenceWithRGBAImage {
   TFLImageClassifierOptions *imageClassifierOptions =
       [[TFLImageClassifierOptions alloc] initWithModelPath:self.modelPath];
- 
   TFLImageClassifier *imageClassifier =
       [TFLImageClassifier imageClassifierWithOptions:imageClassifierOptions error:nil];
   XCTAssertNotNil(imageClassifier);

--- a/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
+++ b/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testInferenceWithRGBAImage {
   TFLImageClassifierOptions *imageClassifierOptions =
       [[TFLImageClassifierOptions alloc] initWithModelPath:self.modelPath];
-
+ 
   TFLImageClassifier *imageClassifier =
       [TFLImageClassifier imageClassifierWithOptions:imageClassifierOptions error:nil];
   XCTAssertNotNil(imageClassifier);

--- a/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
+++ b/tensorflow_lite_support/ios/test/task/vision/image_classifier/TFLImageClassifierTests.m
@@ -112,6 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testInferenceWithRGBAImage {
   TFLImageClassifierOptions *imageClassifierOptions =
       [[TFLImageClassifierOptions alloc] initWithModelPath:self.modelPath];
+
   TFLImageClassifier *imageClassifier =
       [TFLImageClassifier imageClassifierWithOptions:imageClassifierOptions error:nil];
   XCTAssertNotNil(imageClassifier);


### PR DESCRIPTION
The num of threads in TFLBaseOptions was not being set from iOS irrespective of any values passed in TFLBaseOptions.  This issue has been fixed.
