### PR TITLE
Task Library: Added more tests for the BertCluAnnotator Python API

### DIFF
--- a/tensorflow_lite_support/python/test/task/text/bert_clu_annotator_test.py
+++ b/tensorflow_lite_support/python/test/task/text/bert_clu_annotator_test.py
@@ -39,60 +39,37 @@ _BertCluAnnotationOptions = clu_annotation_options_pb2.BertCluAnnotationOptions
 _BERT_MODEL = 'bert_clu_annotator_with_metadata.tflite'
 
 _CLU_REQUEST = _CluRequest(utterances=[
-  'Hi, I would like to make a dinner reservation.'
-  'Of course, what evening will you be joining us on?'
-  'We will need the reservation for Tuesday night.'
-  'What time would you like the reservation for?'
-  'We would prefer 7:00 or 7:30.'
-  'How many people will you need the reservation for?'
-  'There will be 4 of us.'
-  'Fine, I can seat you at 7:00 on Tuesday, if you would kindly give me your '
-  'name.'
-  'Thank you. The last name is Foster.'
-  'See you at 7:00 this Tuesday, Mr. Foster.'
-  'Thank you so much. I appreciate your help.'
+  'I would like to book a reservation at your hotel',
+  'What date would you like to make that reservation for?',
+  'I need the reservation for the 14th of May',
+  'How many days do you need the reservation for?',
+  'I will be staying for 3 nights.',
+  'Is that a single room, or will there be more guests?',
+  'I need a double room.',
+  'We have smoking and nonsmoking rooms. Which do you prefer?',
+  'We require a nonsmoking room.',
+  'Your room is booked. You must arrive before 4:00 pm the day you are to '
+  'check in.'
 ])
 _CLU_RESPONSE = _CluResponse(
   domains=[
     _Category(
-      index=0, score=0.925067, display_name='Restaurants',
-      category_name='')],
+      index=0, score=0.9158045053482056, display_name='Hotels',
+      category_name='')
+  ],
   intents=[
     _Category(
-      index=0, score=0.945974, display_name='ReserveRestaurant',
-      category_name='')],
-  categorical_slots=[
-    _CategoricalSlot(
-      slot='number_of_seats',
-      prediction=_Category(
-        index=0, score=0.784716, display_name='4', category_name=''))
+      index=0, score=0.6116464734077454, display_name='NOTIFY_SUCCESS',
+      category_name='')
   ],
+  categorical_slots=[],
   noncategorical_slots=[
     _NonCategoricalSlot(
-      slot='restaurant_name', extraction=_Extraction(
-        value='Tuesday night', score=0.603665, start=129, end=142)),
-    _NonCategoricalSlot(
-      slot='time', extraction=_Extraction(
-        value='7:00', score=0.907133, start=204, end=208)),
-    _NonCategoricalSlot(
-      slot='time', extraction=_Extraction(
-        value='7:30', score=0.875162, start=212, end=216)),
-    _NonCategoricalSlot(
-      slot='time', extraction=_Extraction(
-        value='7:00', score=0.912969, start=313, end=317)),
-    _NonCategoricalSlot(
-      slot='date', extraction=_Extraction(
-        value='Tuesday', score=0.519359, start=321, end=328)),
-    _NonCategoricalSlot(
-      slot='restaurant_name', extraction=_Extraction(
-        value='Foster', score=0.917109, start=396, end=402)),
-    _NonCategoricalSlot(
-      slot='restaurant_name', extraction=_Extraction(
-        value='See', score=0.917582, start=403, end=406)),
-    _NonCategoricalSlot(
-      slot='time', extraction=_Extraction(
-        value='7:00', score=0.900137, start=414, end=418))
-  ])
+      slot='time',
+      extraction=_Extraction(
+        value='4:00 pm', score=0.7940083146095276, start=44, end=51))
+  ]
+)
 
 
 class ModelFileType(enum.Enum):
@@ -164,39 +141,31 @@ class BertCLUAnnotatorTest(parameterized.TestCase, tf.test.TestCase):
 
   @parameterized.parameters(
     (_CLU_REQUEST, _CluResponse(
-      domains=[], intents=[
+      domains=[],
+      intents=[
         _Category(
-          index=0, score=0.945974, display_name='ReserveRestaurant',
-          category_name='')],
-      categorical_slots=[],
-      noncategorical_slots=[]),
+          index=0, score=0.6116464734077454, display_name='NOTIFY_SUCCESS',
+          category_name='')
+      ], categorical_slots=[], noncategorical_slots=[]),
      0.99, None, 0.99, 0.99),
     (_CLU_REQUEST, _CluResponse(
-      domains=[], intents=[
+      domains=[
         _Category(
-          index=0, score=0.945974, display_name='ReserveRestaurant',
-          category_name='')],
+          index=0, score=0.9158045053482056, display_name='Hotels',
+          category_name='')
+      ],
+      intents=[
+        _Category(
+          index=0, score=0.6116464734077454, display_name='NOTIFY_SUCCESS',
+          category_name='')
+      ],
       categorical_slots=[],
       noncategorical_slots=[
         _NonCategoricalSlot(
           slot='time', extraction=_Extraction(
-            value='7:00', score=0.907133, start=204, end=208)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:30', score=0.875162, start=212, end=216)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:00', score=0.912969, start=313, end=317)),
-        _NonCategoricalSlot(
-          slot='restaurant_name', extraction=_Extraction(
-            value='Foster', score=0.917109, start=396, end=402)),
-        _NonCategoricalSlot(
-          slot='restaurant_name', extraction=_Extraction(
-            value='See', score=0.917582, start=403, end=406)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:00', score=0.900137, start=414, end=418))]),
-     0.99, 0.75, 0.99, 0.75),
+            value='4:00 pm', score=0.7940083146095276, start=44, end=51))
+      ]),
+     0.5, None, 0.99, None),
   )
   def test_thresholds(self, clu_request, expected_clu_response,
                       domain_threshold, intent_threshold,
@@ -231,44 +200,16 @@ class BertCLUAnnotatorTest(parameterized.TestCase, tf.test.TestCase):
     expected_clu_response = _CluResponse(
       domains=[
         _Category(
-          index=0, score=0.925067, display_name='Restaurants',
-          category_name='')],
-      intents=[
-        _Category(
-          index=0, score=0.945974, display_name='ReserveRestaurant',
-          category_name='')],
-      categorical_slots=[
-        _CategoricalSlot(
-          slot='number_of_seats', prediction=_Category(
-            index=0, score=0.784716, display_name='4',
-            category_name='')
-        )],
+          index=0, score=0.916939377784729, display_name='Hotels',
+          category_name='')
+      ],
+      intents=[],
+      categorical_slots=[],
       noncategorical_slots=[
         _NonCategoricalSlot(
-          slot='restaurant_name', extraction=_Extraction(
-            value='Tuesday night', score=0.603665, start=129, end=142)
-        ),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:00', score=0.907133, start=204, end=208)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:30', score=0.875162, start=212, end=216)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:00', score=0.912969, start=313, end=317)),
-        _NonCategoricalSlot(slot='date', extraction=_Extraction(
-          value='Tuesday', score=0.519359, start=321, end=328)),
-        _NonCategoricalSlot(
-          slot='restaurant_name', extraction=_Extraction(
-            value='Foster', score=0.917109, start=396, end=402)),
-        _NonCategoricalSlot(
-          slot='restaurant_name', extraction=_Extraction(
-            value='See', score=0.917582, start=403, end=406)),
-        _NonCategoricalSlot(
-          slot='time', extraction=_Extraction(
-            value='7:00', score=0.900137, start=414, end=418))
-      ])
+          slot='time',
+          extraction=_Extraction(
+            value='4:00 pm', score=0.8557882905006409, start=44, end=51))])
     text_clu_response = annotator.annotate(_CLU_REQUEST)
     self.assertProtoEquals(text_clu_response.to_pb2(),
                            expected_clu_response.to_pb2())

--- a/tensorflow_lite_support/tools/pip_package/BUILD
+++ b/tensorflow_lite_support/tools/pip_package/BUILD
@@ -32,6 +32,7 @@ TASK_PIP_DEPS = [
     "//tensorflow_lite_support/python/task/text:nl_classifier",
     "//tensorflow_lite_support/python/task/text:bert_nl_classifier",
     "//tensorflow_lite_support/python/task/text:bert_question_answerer",
+    "//tensorflow_lite_support/python/task/text:bert_clu_annotator",
     "//tensorflow_lite_support/python/task/audio:audio_classifier",
     "//tensorflow_lite_support/python/task/audio:audio_embedder",
     # For Model Maker Searcher API to build ScaNN index.

--- a/tensorflow_lite_support/tools/pip_package/task_processor.__init__.py
+++ b/tensorflow_lite_support/tools/pip_package/task_processor.__init__.py
@@ -31,6 +31,8 @@ from tensorflow_lite_support.python.task.processor.proto import search_result_pb
 from tensorflow_lite_support.python.task.processor.proto import segmentation_options_pb2
 from tensorflow_lite_support.python.task.processor.proto import segmentations_pb2
 from tensorflow_lite_support.python.task.processor.proto import qa_answers_pb2
+from tensorflow_lite_support.python.task.processor.proto import clu_pb2
+from tensorflow_lite_support.python.task.processor.proto import clu_annotation_options_pb2
 
 BoundingBox = bounding_box_pb2.BoundingBox
 Category = class_pb2.Category
@@ -56,6 +58,12 @@ SegmentationResult = segmentations_pb2.SegmentationResult
 Pos = qa_answers_pb2.Pos
 QaAnswer = qa_answers_pb2.QaAnswer
 QuestionAnswererResult = qa_answers_pb2.QuestionAnswererResult
+CluRequest = clu_pb2.CluRequest
+CluResponse = clu_pb2.CluResponse
+Extraction = clu_pb2.Extraction
+CategoricalSlot = clu_pb2.CategoricalSlot
+NonCategoricalSlot = clu_pb2.NonCategoricalSlot
+BertCluAnnotationOptions = clu_annotation_options_pb2.BertCluAnnotationOptions
 
 # Remove unnecessary modules to avoid duplication in API docs.
 del bounding_box_pb2
@@ -71,3 +79,5 @@ del segmentations_pb2
 del search_options_pb2
 del search_result_pb2
 del qa_answers_pb2
+del clu_pb2
+del clu_annotation_options_pb2

--- a/tensorflow_lite_support/tools/pip_package/task_text.__init__.py
+++ b/tensorflow_lite_support/tools/pip_package/task_text.__init__.py
@@ -23,6 +23,7 @@ from tensorflow_lite_support.python.task.text import text_searcher
 from tensorflow_lite_support.python.task.text import nl_classifier
 from tensorflow_lite_support.python.task.text import bert_nl_classifier
 from tensorflow_lite_support.python.task.text import bert_question_answerer
+from tensorflow_lite_support.python.task.text import bert_clu_annotator
 
 TextEmbedder = text_embedder.TextEmbedder
 TextEmbedderOptions = text_embedder.TextEmbedderOptions
@@ -34,6 +35,8 @@ BertNLClassifier = bert_nl_classifier.BertNLClassifier
 BertNLClassifierOptions = bert_nl_classifier.BertNLClassifierOptions
 BertQuestionAnswerer = bert_question_answerer.BertQuestionAnswerer
 BertQuestionAnswererOptions = bert_question_answerer.BertQuestionAnswererOptions
+BertCluAnnotator = bert_clu_annotator.BertCluAnnotator
+BertCluAnnotatorOptions = bert_clu_annotator.BertCluAnnotatorOptions
 
 # Remove unnecessary modules to avoid duplication in API docs.
 del text_embedder
@@ -41,3 +44,4 @@ del text_searcher
 del nl_classifier
 del bert_nl_classifier
 del bert_question_answerer
+del bert_clu_annotator


### PR DESCRIPTION
- This also includes the BertCluAnnotator to the pip package.

Code snippet for using the BertCluAnnotator API:

```python
from tflite_support.task import text
from tflite_support.task import core
from tflite_support.task import processor

base_options = core.BaseOptions(file_name=model_path)
options = text.BertCluAnnotatorOptions(base_options=base_options)
annotator = text.BertCluAnnotator.create_from_options(options)
# annotator = text.BertCluAnnotator.create_from_file(model_path)
clu_request = processor.CluRequest(...)
text_clu_response = annotator.annotate(clu_request)
print(text_clu_response)
```