### PR TITLE
Added C++ Utils for GMLImage

### DIFF
--- a/tensorflow_lite_support/ios/ios.bzl
+++ b/tensorflow_lite_support/ios/ios.bzl
@@ -1,6 +1,6 @@
 """TensorFlow Lite Support Library Helper Rules for iOS"""
 
-TFL_TASK_MINIMUM_OS_VERSION = "10.0"
+TFL_TASK_MINIMUM_OS_VERSION = "11.0"
 
 # When the static framework is built with bazel, the all header files are moved
 # to the "Headers" directory with no header path prefixes. This auxiliary rule

--- a/tensorflow_lite_support/ios/sources/TFLCommonCppUtils.mm
+++ b/tensorflow_lite_support/ios/sources/TFLCommonCppUtils.mm
@@ -35,7 +35,7 @@
 }
 
 + (BOOL)checkCppError:(const absl::Status &)status toError:(NSError *_Nullable *)error {
-  if (!status.ok()) {
+  if (status.ok()) {
     return YES;
   }
   // Payload of absl::Status created by the tflite task library stores an appropriate value of the

--- a/tensorflow_lite_support/ios/task/vision/utils/BUILD
+++ b/tensorflow_lite_support/ios/task/vision/utils/BUILD
@@ -12,10 +12,31 @@ objc_library(
         "sources/GMLImage+Utils.h",
     ],
     features = ["-layering_check"],
+    sdk_frameworks = ["CoreVideo", "CoreGraphics", "Accelerate", "CoreMedia"],
     module_name = "GMLImageUtils",
     deps = [
         "//tensorflow_lite_support/c/task/vision/core:frame_buffer",
         "//tensorflow_lite_support/ios:TFLCommonUtils",
         "//tensorflow_lite_support/odml/ios/image:MLImage",
     ],
+)
+
+objc_library(
+    name = "GMLImageCppUtils",
+    srcs = [
+        "sources/GMLImage+CppUtils.mm",
+    ],
+    hdrs = [
+        "sources/GMLImage+CppUtils.h",
+    ],
+    features = ["-layering_check"],
+    module_name = "GMLImageCppUtils",
+    deps = [
+        ":GMLImageUtils",
+        "//tensorflow_lite_support/ios:TFLCommonCppUtils",
+        "//tensorflow_lite_support/cc/task/vision/core:frame_buffer",
+        "//tensorflow_lite_support/odml/ios/image:MLImage",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+    copts = ["-ObjC++","-std=c++14"]
 )

--- a/tensorflow_lite_support/ios/task/vision/utils/BUILD
+++ b/tensorflow_lite_support/ios/task/vision/utils/BUILD
@@ -12,7 +12,7 @@ objc_library(
         "sources/GMLImage+Utils.h",
     ],
     features = ["-layering_check"],
-    sdk_frameworks = ["CoreVideo", "CoreGraphics", "Accelerate", "CoreMedia"],
+    sdk_frameworks = ["CoreVideo", "CoreGraphics", "Accelerate", "CoreImage"],
     module_name = "GMLImageUtils",
     deps = [
         "//tensorflow_lite_support/c/task/vision/core:frame_buffer",
@@ -38,5 +38,4 @@ objc_library(
         "//tensorflow_lite_support/odml/ios/image:MLImage",
         "@com_google_absl//absl/strings:str_format",
     ],
-    copts = ["-ObjC++","-std=c++14"]
 )

--- a/tensorflow_lite_support/ios/task/vision/utils/BUILD
+++ b/tensorflow_lite_support/ios/task/vision/utils/BUILD
@@ -12,7 +12,7 @@ objc_library(
         "sources/GMLImage+Utils.h",
     ],
     features = ["-layering_check"],
-    sdk_frameworks = ["CoreVideo", "CoreGraphics", "Accelerate", "CoreImage"],
+    sdk_frameworks = ["CoreGraphics", "CoreVideo", "Accelerate", "CoreMedia"],
     module_name = "GMLImageUtils",
     deps = [
         "//tensorflow_lite_support/c/task/vision/core:frame_buffer",

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
@@ -20,20 +20,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Helper utility for converting GMLImage to C++ FrameBuffer accepted by the TF Lite Task Vision
- * C++ library.
+/** Helper utility for converting GMLImage to C++ FrameBuffer accepted by the 
+ * TF Lite Task Vision C++ library.
  */
 @interface GMLImage (CppUtils)
 
 /**
- * Creates and returns a C++ FrameBuffer from a GMLImage. tflite::task::vision::FrameBuffer is used
- * by the TFLite Task Vision C++ library to hold the backing buffer of any image.
+ * Creates and returns a C++ FrameBuffer from a GMLImage. 
+ * tflite::task::vision::FrameBuffer is used by the TFLite Task Vision C++ 
+ * library to hold the backing buffer of any image.
  *
- * @param error Pointer to the memory location where errors if any should be saved. If `nil`, no
- * error will be saved.
+ * @param error Pointer to the memory location where errors if any should be 
+ * saved. If `nil`, no error will be saved.
  *
- * @return The FrameBuffer created from the gmlImage which can be used with the TF Lite Task Vision
- * C++ library. `nil` in case of an error.
+ * @return The FrameBuffer created from the gmlImage which can be used with the 
+ * TF Lite Task Vision C++ library. `nil` in case of an error.
  */
 - (std::unique_ptr<tflite::task::vision::FrameBuffer>)cppFrameBufferWithError:
     (NSError *_Nullable *)error;

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
@@ -1,0 +1,44 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================*/
+#import <Foundation/Foundation.h>
+
+#include "tensorflow_lite_support/cc/task/vision/core/frame_buffer.h"
+
+#import "tensorflow_lite_support/odml/ios/image/apis/GMLImage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Helper utility for converting GMLImage to C++ FrameBuffer accepted by the TF Lite Task Vision
+ * C++ library.
+ */
+@interface GMLImage (CppUtils)
+
+/**
+ * Creates and returns a C++ FrameBuffer from a GMLImage. tflite::task::vision::FrameBuffer is used
+ * by the TFLite Task Vision C++ library to hold the backing buffer of any image. Image inputs to
+ * the TFLite Task Vision C library is of type TfLiteFrameBuffer.
+ *
+ * @param error Pointer to the memory location where errors if any should be saved. If `nil`, no
+ * error will be saved.
+ *
+ * @return The FrameBuffer created from the gmlImage which can be used with the TF Lite Task Vision
+ * C++ library.
+ */
+- (std::unique_ptr<tflite::task::vision::FrameBuffer>)cppFrameBufferWithError:
+    (NSError *_Nullable *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h
@@ -27,14 +27,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Creates and returns a C++ FrameBuffer from a GMLImage. tflite::task::vision::FrameBuffer is used
- * by the TFLite Task Vision C++ library to hold the backing buffer of any image. Image inputs to
- * the TFLite Task Vision C library is of type TfLiteFrameBuffer.
+ * by the TFLite Task Vision C++ library to hold the backing buffer of any image.
  *
  * @param error Pointer to the memory location where errors if any should be saved. If `nil`, no
  * error will be saved.
  *
  * @return The FrameBuffer created from the gmlImage which can be used with the TF Lite Task Vision
- * C++ library.
+ * C++ library. `nil` in case of an error.
  */
 - (std::unique_ptr<tflite::task::vision::FrameBuffer>)cppFrameBufferWithError:
     (NSError *_Nullable *)error;

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
@@ -1,0 +1,50 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ==============================================================================*/
+#import "tensorflow_lite_support/ios/sources/TFLCommonCppUtils.h"
+#import "tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.h"
+#import "tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h"
+
+#include "absl/strings/str_format.h"  // from @com_google_absl
+#include "tensorflow_lite_support/cc/task/vision/utils/frame_buffer_common_utils.h"
+
+namespace {
+using FrameBufferCpp = ::tflite::task::vision::FrameBuffer;
+using ::tflite::support::StatusOr;
+}  // namespace
+
+@implementation GMLImage (CppUtils)
+
+- (std::unique_ptr<FrameBufferCpp>)cppFrameBufferWithError:(NSError *_Nullable *)error {
+  uint8_t *buffer = [self bufferWithError:error];
+
+  if (!buffer) {
+    return NULL;
+  }
+
+  CGSize bitmapSize = self.bitmapSize;
+  FrameBufferCpp::Format frame_buffer_format = FrameBufferCpp::Format::kRGB;
+
+  StatusOr<std::unique_ptr<FrameBufferCpp>> frameBuffer =
+      CreateFromRawBuffer(buffer, {(int)bitmapSize.width, (int)bitmapSize.height},
+                          frame_buffer_format, FrameBufferCpp::Orientation::kTopLeft);
+
+  if (![TFLCommonCppUtils checkCppError:frameBuffer.status() toError:error]) {
+    return NULL;
+  }
+
+  return std::move(frameBuffer.value());
+}
+
+@end

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
@@ -44,7 +44,7 @@ using ::tflite::support::StatusOr;
     return NULL;
   }
 
-  return frameBuffer.value();
+  return std::move(frameBuffer.value());
 }
 
 @end

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+CppUtils.mm
@@ -44,7 +44,7 @@ using ::tflite::support::StatusOr;
     return NULL;
   }
 
-  return std::move(frameBuffer.value());
+  return frameBuffer.value();
 }
 
 @end

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
@@ -15,6 +15,7 @@
 #import <Foundation/Foundation.h>
 
 #include "tensorflow_lite_support/c/task/vision/core/frame_buffer.h"
+
 #import "tensorflow_lite_support/odml/ios/image/apis/GMLImage.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -24,27 +25,38 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GMLImage (Utils)
 
+/** Bitmap size of the image*/
+@property(nonatomic, readonly) CGSize bitmapSize;
+
 /**
- * Creates and returns a TfLiteFrameBuffer from a GMLImage. TfLiteFrameBuffer
- * is used by the TFLite Task Vision C library to hold the backing buffer of
- * any image. Image inputs to the TFLite Task Vision C library is of type
- * TfLiteFrameBuffer.
+ * Returns the underlying uint8 pixel buffer of a GMLImage.
  *
  * @param error Pointer to the memory location where errors if any should be
  * saved. If `nil`, no error will be saved.
  *
- * @return The TfLiteFrameBuffer created from the gmlImage which can be used
- * with the TF Lite Task Vision C library.
+ * @return The underlying pixel buffer of gmlImage or nil in case of errors.
+ */
+- (nullable uint8_t *)bufferWithError:(NSError *_Nullable *)error;
+
+/**
+ * Creates and returns a TfLiteFrameBuffer from a GMLImage. TfLiteFrameBuffer is used by the TFLite
+ * Task Vision C library to hold the backing buffer of any image. Image inputs to the TFLite Task
+ * Vision C library is of type TfLiteFrameBuffer.
+ *
+ * @param error Pointer to the memory location where errors if any should be saved. If `nil`, no
+ * error will be saved.
+ *
+ * @return The TfLiteFrameBuffer created from the gmlImage which can be used with the TF Lite Task
+ * Vision C library.
  */
 - (nullable TfLiteFrameBuffer *)cFrameBufferWithError:(NSError *_Nullable *)error;
 
 /**
- * Gets grayscale pixel buffer from GMLImage if source type is
- * GMLImageSourceTypeImage.
+ * Gets grayscale pixel buffer from GMLImage if source type is GMLImageSourceTypeImage.
  *
- * @warning Currently method only returns gray scale pixel buffer if source type
- * is GMLImageSourceTypeImage since extracting gray scale pixel buffer from
- * other source types is not a necessity for the current testing framework.
+ * @warning Currently method only returns gray scale pixel buffer if source type is
+ * GMLImageSourceTypeImage since extracting gray scale pixel buffer from other source types is not a
+ * necessity for the current testing framework.
  *
  * @return The CVPixelBufferRef for the newly created gray scale pixel buffer.
  */
@@ -53,13 +65,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Loads an image from a file in an app bundle into a GMLImage object.
  *
- * @param classObject The specified class associated with the bundle containing
- * the file to be loaded.
+ * @param classObject The specified class associated with the bundle containingthe file to be
+ * loaded.
  * @param name Name of the image file.
  * @param type Extenstion of the image file.
  *
- * @return The GMLImage object contains the loaded image. This method returns
- * nil if it cannot load the image.
+ * @return The GMLImage object contains the loaded image. This method returns nil if it cannot load
+ * the image.
  */
 + (nullable GMLImage *)imageFromBundleWithClass:(Class)classObject
                                        fileName:(NSString *)name

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
@@ -39,24 +39,26 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable uint8_t *)bufferWithError:(NSError *_Nullable *)error;
 
 /**
- * Creates and returns a TfLiteFrameBuffer from a GMLImage. TfLiteFrameBuffer is used by the TFLite
- * Task Vision C library to hold the backing buffer of any image. Image inputs to the TFLite Task
- * Vision C library is of type TfLiteFrameBuffer.
+ * Creates and returns a TfLiteFrameBuffer from a GMLImage. TfLiteFrameBuffer is 
+ * used by the TFLite Task Vision C library to hold the backing buffer of any 
+ * image. Image inputs to the TFLite Task Vision C library is of type 
+ * TfLiteFrameBuffer.
  *
- * @param error Pointer to the memory location where errors if any should be saved. If `nil`, no
- * error will be saved.
+ * @param error Pointer to the memory location where errors if any should be 
+ * saved. If `nil`, no error will be saved.
  *
- * @return The TfLiteFrameBuffer created from the gmlImage which can be used with the TF Lite Task
- * Vision C library.
+ * @return The TfLiteFrameBuffer created from the gmlImage which can be used 
+ * with the TF Lite Task Vision C library.
  */
 - (nullable TfLiteFrameBuffer *)cFrameBufferWithError:(NSError *_Nullable *)error;
 
 /**
- * Gets grayscale pixel buffer from GMLImage if source type is GMLImageSourceTypeImage.
+ * Gets grayscale pixel buffer from GMLImage if source type is 
+ * GMLImageSourceTypeImage.
  *
- * @warning Currently method only returns gray scale pixel buffer if source type is
- * GMLImageSourceTypeImage since extracting gray scale pixel buffer from other source types is not a
- * necessity for the current testing framework.
+ * @warning Currently method only returns gray scale pixel buffer if source type 
+ * is GMLImageSourceTypeImage since extracting gray scale pixel buffer from 
+ * other source types is not a necessity for the current testing framework.
  *
  * @return The CVPixelBufferRef for the newly created gray scale pixel buffer.
  */
@@ -65,13 +67,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Loads an image from a file in an app bundle into a GMLImage object.
  *
- * @param classObject The specified class associated with the bundle containing the file to be
- * loaded.
+ * @param classObject The specified class associated with the bundle containing 
+ * the file to be loaded.
  * @param name Name of the image file.
  * @param type Extenstion of the image file.
  *
- * @return The GMLImage object contains the loaded image. This method returns nil if it cannot load
- * the image.
+ * @return The GMLImage object contains the loaded image. This method returns 
+ * nil if it cannot load the image.
  */
 + (nullable GMLImage *)imageFromBundleWithClass:(Class)classObject
                                        fileName:(NSString *)name

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Loads an image from a file in an app bundle into a GMLImage object.
  *
- * @param classObject The specified class associated with the bundle containingthe file to be
+ * @param classObject The specified class associated with the bundle containing the file to be
  * loaded.
  * @param name Name of the image file.
  * @param type Extenstion of the image file.

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
@@ -18,7 +18,7 @@
 
 #import <Accelerate/Accelerate.h>
 #import <CoreGraphics/CoreGraphics.h>
-#import <CoreMedia/CoreMedia.h>
+#import <CoreImage/CoreImage.h>
 #import <CoreVideo/CoreVideo.h>
 
 @interface TFLCVPixelBufferUtils : NSObject
@@ -46,7 +46,7 @@
   size_t destinationBytesPerRow = width * destinationChannelCount;
 
   uint8_t *destPixelBufferAddress =
-      (uint8_t *)[TFLCommonUtils mallocWithSize:sizeof(uint8_t) * height * destinationBytesPerRow
+      [TFLCommonUtils mallocWithSize:sizeof(uint8_t) * height * destinationBytesPerRow
                                           error:error];
 
   if (!destPixelBufferAddress) {
@@ -103,7 +103,7 @@
   CVPixelBufferLockBaseAddress(pixelBuffer, 0);
 
   uint8_t *rgbData = [TFLCVPixelBufferUtils
-      createRGBImageDatafromImageData:(uint8_t *)CVPixelBufferGetBaseAddress(pixelBuffer)
+      createRGBImageDatafromImageData:CVPixelBufferGetBaseAddress(pixelBuffer)
                             withWidth:CVPixelBufferGetWidth(pixelBuffer)
                                height:CVPixelBufferGetHeight(pixelBuffer)
                                stride:CVPixelBufferGetBytesPerRow(pixelBuffer)
@@ -225,7 +225,7 @@
 
   if (context) {
     CGContextDrawImage(context, CGRectMake(0, 0, width, height), cgImage);
-    uint8_t *srcData = (uint8_t *)CGBitmapContextGetData(context);
+    uint8_t *srcData = CGBitmapContextGetData(context);
 
     if (srcData) {
       // We have drawn the image as an RGBA image with 8 bitsPerComponent and hence can safely input

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
@@ -170,7 +170,7 @@
     height = CVPixelBufferGetHeight(self.CIImage.pixelBuffer);
   } else if (self.CIImage.CGImage) {
     width = CGImageGetWidth(self.CIImage.CGImage);
-    height = CGImageGetWidth(self.CIImage.CGImage);
+    height = CGImageGetHeight(self.CIImage.CGImage);
   }
   return CGSizeMake(width, height);
 }

--- a/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
+++ b/tensorflow_lite_support/ios/task/vision/utils/sources/GMLImage+Utils.m
@@ -256,20 +256,12 @@
 - (uint8_t *)frameBufferFromCIImage:(CIImage *)ciImage error:(NSError **)error {
   uint8_t *buffer = NULL;
 
-  int width = 0;
-  int height = 0;
-
   if (ciImage.pixelBuffer) {
-    width = (int)CVPixelBufferGetWidth(ciImage.pixelBuffer);
-    height = (int)CVPixelBufferGetHeight(ciImage.pixelBuffer);
-
     buffer = [TFLCVPixelBufferUtils createRGBImageDatafromCVPixelBuffer:ciImage.pixelBuffer
                                                                   error:error];
 
   } else if (ciImage.CGImage) {
     buffer = [UIImage pixelDataFromCGImage:ciImage.CGImage error:error];
-    width = (int)CGImageGetWidth(ciImage.CGImage);
-    height = (int)CGImageGetWidth(ciImage.CGImage);
   } else {
     [TFLCommonUtils createCustomError:error
                              withCode:TFLSupportErrorCodeInvalidArgumentError

--- a/tensorflow_lite_support/ios/test/task/vision/image_classifier/BUILD
+++ b/tensorflow_lite_support/ios/test/task/vision/image_classifier/BUILD
@@ -1,7 +1,11 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@org_tensorflow//tensorflow/lite/ios:ios.bzl", "TFL_DEFAULT_TAGS", "TFL_DISABLED_SANITIZER_TAGS", "TFL_MINIMUM_OS_VERSION")
+load("@org_tensorflow//tensorflow/lite/ios:ios.bzl", "TFL_DEFAULT_TAGS", "TFL_DISABLED_SANITIZER_TAGS")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@org_tensorflow//tensorflow/lite:special_rules.bzl", "tflite_ios_lab_runner")
+load(
+    "//tensorflow_lite_support/ios:ios.bzl",
+    "TFL_TASK_MINIMUM_OS_VERSION",
+)
 
 package(
     default_visibility = ["//visibility:private"],
@@ -25,7 +29,7 @@ swift_library(
 
 ios_unit_test(
     name = "TFLImageClassifierSwiftTest",
-    minimum_os_version = TFL_MINIMUM_OS_VERSION,
+    minimum_os_version = TFL_TASK_MINIMUM_OS_VERSION,
     runner = tflite_ios_lab_runner("IOS_LATEST"),
     tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
     deps = [
@@ -50,7 +54,7 @@ objc_library(
 
 ios_unit_test(
     name = "TFLImageClassifierObjcTest",
-    minimum_os_version = TFL_MINIMUM_OS_VERSION,
+    minimum_os_version = TFL_TASK_MINIMUM_OS_VERSION,
     runner = tflite_ios_lab_runner("IOS_LATEST"),
     tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
     deps = [
@@ -79,7 +83,7 @@ objc_library(
 
 ios_unit_test(
     name = "TFLImageClassifierCoreMLDelegateTest",
-    minimum_os_version = TFL_MINIMUM_OS_VERSION,
+    minimum_os_version = TFL_TASK_MINIMUM_OS_VERSION,
     runner = tflite_ios_lab_runner("IOS_LATEST"),
     tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
     deps = [


### PR DESCRIPTION
1. Refactored GMLImage Utils to enable creation of C++ and C frame buffers with common functions.
2. Added C++ GMLImage Utils for creating C++ frame buffer from GMLImage.