### PR TITLE
remove minizip ioapi include

### DIFF
--- a/tensorflow_lite_support/metadata/cc/utils/zip_readonly_mem_file.cc
+++ b/tensorflow_lite_support/metadata/cc/utils/zip_readonly_mem_file.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <cstdio>
 
 #include "absl/strings/string_view.h"  // from @com_google_absl
-#include "contrib/minizip/ioapi.h"
 
 namespace tflite {
 namespace metadata {

--- a/tensorflow_lite_support/metadata/cc/utils/zip_writable_mem_file.cc
+++ b/tensorflow_lite_support/metadata/cc/utils/zip_writable_mem_file.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <cstdio>
 
 #include "absl/strings/string_view.h"  // from @com_google_absl
-#include "contrib/minizip/ioapi.h"
 
 namespace tflite {
 namespace metadata {


### PR DESCRIPTION
The path requires patching in chromium for system zlib builds. However,
it is not needed in the cc files, because it is already present in
the header files.