### PR TITLE
fix typos

### DIFF
--- a/tensorflow_lite_support/metadata/python/metadata_writers/bert_nl_classifier.py
+++ b/tensorflow_lite_support/metadata/python/metadata_writers/bert_nl_classifier.py
@@ -76,7 +76,7 @@ class MetadataWriter(metadata_writer.MetadataWriter):
     return cls.create_from_metadata(
         model_buffer,
         model_metadata=general_md.create_metadata(),
-        input_metadata=input_md.create_input_tesnor_metadata(),
+        input_metadata=input_md.create_input_tensor_metadata(),
         output_metadata=[output_md.create_metadata()],
         associated_files=[
             file.file_path for file in output_md.associated_files
@@ -108,7 +108,7 @@ class MetadataWriter(metadata_writer.MetadataWriter):
     Args:
       model_buffer: valid buffer of the model file.
       tokenizer_md: information of the tokenizer used to process the input
-        string, if any. Supported tokenziers are: `BertTokenizer` [1] and
+        string, if any. Supported tokenizers are: `BertTokenizer` [1] and
           `SentencePieceTokenizer` [2]. If the tokenizer is `RegexTokenizer`
           [3], refer to `nl_classifier.MetadataWriter`.
         [1]:

--- a/tensorflow_lite_support/metadata/python/metadata_writers/metadata_info.py
+++ b/tensorflow_lite_support/metadata/python/metadata_writers/metadata_info.py
@@ -789,8 +789,8 @@ class BertInputTensorsMd:
 
     self._tokenizer_md = tokenizer_md
 
-  def create_input_tesnor_metadata(self) -> List[_metadata_fb.TensorMetadataT]:
-    """Creates the input metadata for the three input tesnors."""
+  def create_input_tensor_metadata(self) -> List[_metadata_fb.TensorMetadataT]:
+    """Creates the input metadata for the three input tensors."""
     # The order of the three input tensors may vary with each model conversion.
     # We need to order the input metadata according to the tensor order in the
     # model.

--- a/tensorflow_lite_support/python/task/audio/core/audio_record.py
+++ b/tensorflow_lite_support/python/task/audio/core/audio_record.py
@@ -48,11 +48,11 @@ class AudioRecord(object):
       raise sd_error
 
     if channels <= 0:
-      raise ValueError('channels must be postive.')
+      raise ValueError('channels must be positive.')
     if sampling_rate <= 0:
-      raise ValueError('sampling_rate must be postive.')
+      raise ValueError('sampling_rate must be positive.')
     if buffer_size <= 0:
-      raise ValueError('buffer_size must be postive.')
+      raise ValueError('buffer_size must be positive.')
 
     self._audio_buffer = []
     self._buffer_size = buffer_size


### PR DESCRIPTION
Quick typo fixes.

Main one is in a referenced function, create_input_tesnor_metadata. Looks as though there is only one reference in the project.