### PR TITLE
Document updated for the broken link of codegen

### DIFF
--- a/tensorflow_lite_support/metadata/README.md
+++ b/tensorflow_lite_support/metadata/README.md
@@ -12,4 +12,4 @@ documentation](https://www.tensorflow.org/lite/convert/metadata).
 The first code generator which takes advantage of this metadata format is the
 TensorFlow Lite Android Code Generator. For more information on how to use this
 generator, please refer to the [TensorFlow Lite Android wrapper code generator
-documentation](https://www.tensorflow.org/lite/guide/codegen).
+documentation](https://www.tensorflow.org/lite/inference_with_metadata/codegen).


### PR DESCRIPTION
The link for codegen was directing to this page "https://www.tensorflow.org/lite/guide/codegen " so I updated the broken link with the correct one. Thank you!