### PR TITLE
Fix whitespace typo for Bert Question Answerer test in README.md

### DIFF
--- a/tensorflow_lite_support/examples/task/text/desktop/README.md
+++ b/tensorflow_lite_support/examples/task/text/desktop/README.md
@@ -27,11 +27,11 @@ bazel run -c opt \
  tensorflow_lite_support/examples/task/text/desktop:bert_question_answerer_demo -- \
  --model_path=/tmp/mobilebert.tflite \
  --question="Where is Amazon rainforest?" \
- --context="The Amazon rainforest, alternatively, the Amazon Jungle, also known in \
-English as Amazonia, is a moist broadleaf tropical rainforest in the Amazon \
-biome that covers most of the Amazon basin of South America. This basin \
-encompasses 7,000,000 km2 (2,700,000 sq mi), of which \
-5,500,000 km2 (2,100,000 sq mi) are covered by the rainforest. This region \
+ --context="The Amazon rainforest, alternatively, the Amazon Jungle, also known in \
+English as Amazonia, is a moist broadleaf tropical rainforest in the Amazon \
+biome that covers most of the Amazon basin of South America. This basin \
+encompasses 7,000,000 km2 (2,700,000 sq mi), of which \
+5,500,000 km2 (2,100,000 sq mi) are covered by the rainforest. This region \
 includes territory belonging to nine nations."
 ```
 


### PR DESCRIPTION
In the Bert QA testcase provided by README.md, I think the context is seperated by different types of whitespace. I also print the results of the subwords of tokens. It shows these.
```
context: The Amazon rainforest, alternatively, the Amazon Jungle, also known in English as Amazonia, is a moist broadleaf tropical rainforest in the Amazon biome that covers most of the Amazon basin of South America. This basin encompasses 7,000,000 km2 (2,700,000 sq mi), of which 5,500,000 km2 (2,100,000 sq mi) are covered by the rainforest. This region includes territory belonging to nine nations.

orig_tokens: {The Amazon}, {rainforest,}, {alternatively,}, {the Amazon}, {Jungle,}, {also}, {known}, {in}, {English}, {as Amazonia,}, {is}, {a moist}, {broadleaf tropical rainforest in}, {the Amazon}, {biome that}, {covers}, {most}, {of}, {the Amazon}, {basin of}, {South}, {America.}, {This}, {basin}, {encompasses}, {7,000,000 km2 (2,700,000 sq mi),}, {of}, {which}, {5,500,000 km2 (2,100,000 sq mi)}, {are}, {covered}, {by}, {the}, {rainforest.}, {This}, {region}, {includes}, {territory}, {belonging}, {to}, {nine}, {nations.}
```
So the tokens are not correctly been seperated by the absl::StrSplit() in https://github.com/tensorflow/tflite-support/blob/2ab77502e1f2937923ef105547c1196a1e81a1c4/tensorflow_lite_support/cc/task/text/bert_question_answerer.cc#L205

I check the hex values of the origin context string it shows typos about whitespace in the context and I patch the issue.